### PR TITLE
IOS-1943 Don't force access code to be requested

### DIFF
--- a/TangemSdk/TangemSdk/Common/Core/CardSession.swift
+++ b/TangemSdk/TangemSdk/Common/Core/CardSession.swift
@@ -359,7 +359,7 @@ public class CardSession {
                      }
                  }
             } else {
-                requestAccessCodeAction()
+                runnable.prepare(self, completion: completion)
             }
         case .always:
             requestAccessCodeAction()


### PR DESCRIPTION
Фикс для ситуации когда у пользователя включено сохранение кодов, но ни одного кода не сохранено. Это может произойти если зайти в настройки и переподключить тоггл сохранения. 

Пользователь потом пытается добавить новую карту в список сохраненных и мы запрашиваем у него код, потом устанавливаем его в environment. Если пользователь пытается отсканировать карту без кода, то выйдет ошибка.

Сделал МР чтобы изменения не потерялись, можно или отдельно залить, или еще подождать какие-то дополнительные изменения.