### PR TITLE
IOS-2389 Set default keyboard type

### DIFF
--- a/TangemSdk/TangemSdk/UI/Views/Common/FloatingTextField.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Common/FloatingTextField.swift
@@ -51,7 +51,7 @@ struct FloatingTextField: View {
                         .scaleEffect(text.wrappedValue.isEmpty ? 1 : 0.76, anchor: .leading)
                     
                     textField
-                        .keyboardType(.alphabet)
+                        .keyboardType(.default)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .font(.system(size: 17))

--- a/TangemSdk/TangemSdk/UI/Views/Common/FocusableTextField.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Common/FocusableTextField.swift
@@ -30,6 +30,7 @@ struct FocusableTextField: View {
                     .focused($focusedField, equals: .plain)
             }
         }
+        .keyboardType(.default)
         .onAppear(perform: model.onAppear)
         .onChange(of: isSecured) { newValue in
             setFocus(for: newValue)


### PR DESCRIPTION
Поставил в двух местах, чтобы в случае использования компонента отдельно, модификатор не потерялся