### PR TITLE
IOS-2393 Add reset-pin service localisation

### DIFF
--- a/TangemSdk/TangemSdk/Common/Extensions/String+.swift
+++ b/TangemSdk/TangemSdk/Common/Extensions/String+.swift
@@ -44,6 +44,12 @@ public extension String {
     }
     
     @available(iOS 13.0, *)
+    internal func localized(_ arguments: [CVarArg]) -> String {
+        let format = Localization.getFormat(for: self)
+        return String(format: format, arguments: arguments)
+    }
+    
+    @available(iOS 13.0, *)
     internal func localized(_ arguments: CVarArg) -> String {
         let format = Localization.getFormat(for: self)
         return String(format: format, arguments)

--- a/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
@@ -62,4 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
-"sign_multiple_chunks_part" = "Signing part %@ of %@";
+"sign_multiple_chunks_part" = "Signing part %d of %d";

--- a/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
@@ -62,3 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
+"sign_multiple_chunks_part" = "Signing part %@ of %@";

--- a/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
@@ -53,6 +53,9 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_confirmation_card" = "Scan another linked card";
+"reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";
 "reset_codes_message_body_restore" = "First, prepare the card for restore process";
 "reset_codes_message_title_backup" = "Tap a backup card";

--- a/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/de.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
-"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the %@";
 "reset_codes_scan_confirmation_card" = "Scan another linked card";
 "reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";

--- a/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
@@ -62,4 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
-"sign_multiple_chunks_part" = "Signing part %@ of %@";
+"sign_multiple_chunks_part" = "Signing part %d of %d";

--- a/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
@@ -62,3 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
+"sign_multiple_chunks_part" = "Signing part %@ of %@";

--- a/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
@@ -53,6 +53,9 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_confirmation_card" = "Scan another linked card";
+"reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";
 "reset_codes_message_body_restore" = "First, prepare the card for restore process";
 "reset_codes_message_title_backup" = "Tap a backup card";

--- a/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/en.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
-"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the %@";
 "reset_codes_scan_confirmation_card" = "Scan another linked card";
 "reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";

--- a/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
@@ -62,4 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
-"sign_multiple_chunks_part" = "Signing part %@ of %@";
+"sign_multiple_chunks_part" = "Signing part %d of %d";

--- a/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
@@ -62,3 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
+"sign_multiple_chunks_part" = "Signing part %@ of %@";

--- a/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
@@ -53,6 +53,9 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_confirmation_card" = "Scan another linked card";
+"reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";
 "reset_codes_message_body_restore" = "First, prepare the card for restore process";
 "reset_codes_message_title_backup" = "Tap a backup card";

--- a/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/fr.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
-"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the %@";
 "reset_codes_scan_confirmation_card" = "Scan another linked card";
 "reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";

--- a/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
@@ -62,4 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
-"sign_multiple_chunks_part" = "Signing part %@ of %@";
+"sign_multiple_chunks_part" = "Signing part %d of %d";

--- a/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
@@ -62,3 +62,4 @@
 "reset_codes_message_body_backup" = "Tap the linked card";
 "reset_codes_message_body_restore_final" = "Tap the restore card again";
 "reset_codes_success_message" = "Code was reset successfully";
+"sign_multiple_chunks_part" = "Signing part %@ of %@";

--- a/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
@@ -53,6 +53,9 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_confirmation_card" = "Scan another linked card";
+"reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";
 "reset_codes_message_body_restore" = "First, prepare the card for restore process";
 "reset_codes_message_title_backup" = "Tap a backup card";

--- a/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/it.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "attestation_online_failed_title" = "Online attestation failed";
 "attestation_online_failed_body" = "We cannot finish card's online attestation at this time. You can continue at your own risk and try again later, retry now or cancel the operation";
 "attestation_warning_attest_wallets" = "Too many runs of Attest Wallet or Sign looks suspicious.";
-"reset_codes_scan_first_card" = "Scan the card on which you want to reset the pin";
+"reset_codes_scan_first_card" = "Scan the card on which you want to reset the %@";
 "reset_codes_scan_confirmation_card" = "Scan another linked card";
 "reset_codes_scan_to_reset" = "Scan card to reset user codes";
 "reset_codes_message_title_restore" = "Tap the card you want to restore";

--- a/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
@@ -53,6 +53,9 @@
 "attestation_online_failed_title" = "Онлайн-аттестация не удалась";
 "attestation_online_failed_body" = "В настоящее время мы не можем завершить онлайн-аттестацию карты. Вы можете продолжить на свой страх и риск и повторить попытку позже, повторить сейчас или отменить операцию.";
 "attestation_warning_attest_wallets" = "Слишком большое количество вызовов Attest Wallet или Sign выглядит подозрительно.";
+"reset_codes_scan_first_card" = "Отсканируйте карту, на которой вы хотите сбросить пин-код";
+"reset_codes_scan_confirmation_card" = "Отсканируйте другую привязанную карту";
+"reset_codes_scan_to_reset" = "Отсканируйте карту для сброса кода";
 "reset_codes_message_title_restore" = "Отсканируйте карту, которую хотите восстановить";
 "reset_codes_message_body_restore" = "Сначала подготовьте карту к процессу восстановления";
 "reset_codes_message_title_backup" = "Приложите резервную карту";

--- a/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
@@ -62,3 +62,4 @@
 "reset_codes_message_body_backup" = "Приложите связанную карту";
 "reset_codes_message_body_restore_final" = "Приложите еще раз карту, которую хотите восстановить";
 "reset_codes_success_message" = "Код успешно сброшен";
+"sign_multiple_chunks_part" = "Подпись части %@ из %@";

--- a/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
@@ -62,4 +62,4 @@
 "reset_codes_message_body_backup" = "Приложите связанную карту";
 "reset_codes_message_body_restore_final" = "Приложите еще раз карту, которую хотите восстановить";
 "reset_codes_success_message" = "Код успешно сброшен";
-"sign_multiple_chunks_part" = "Подпись части %@ из %@";
+"sign_multiple_chunks_part" = "Подпись части %d из %d";

--- a/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
+++ b/TangemSdk/TangemSdk/Common/Localization/ru.lproj/Localizable.strings
@@ -53,7 +53,7 @@
 "attestation_online_failed_title" = "Онлайн-аттестация не удалась";
 "attestation_online_failed_body" = "В настоящее время мы не можем завершить онлайн-аттестацию карты. Вы можете продолжить на свой страх и риск и повторить попытку позже, повторить сейчас или отменить операцию.";
 "attestation_warning_attest_wallets" = "Слишком большое количество вызовов Attest Wallet или Sign выглядит подозрительно.";
-"reset_codes_scan_first_card" = "Отсканируйте карту, на которой вы хотите сбросить пин-код";
+"reset_codes_scan_first_card" = "Отсканируйте карту, на которой вы хотите сбросить %@";
 "reset_codes_scan_confirmation_card" = "Отсканируйте другую привязанную карту";
 "reset_codes_scan_to_reset" = "Отсканируйте карту для сброса кода";
 "reset_codes_message_title_restore" = "Отсканируйте карту, которую хотите восстановить";

--- a/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
+++ b/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
@@ -93,7 +93,7 @@ public class ResetPinService: ObservableObject {
     private func scanResetPinCard(resetCardId: String?, _ completion: @escaping CompletionResult<Void>) {
         self.session = TangemSdk().makeSession(with: config,
                                                cardId: resetCardId,
-                                               initialMessage: Message(header: "Scan the card on which you want to reset the pin"))
+                                               initialMessage: Message(header: "reset_codes_scan_first_card".localized))
         
         session!.start(with: GetResetPinTokenCommand()) { result in
             switch result {
@@ -114,7 +114,7 @@ public class ResetPinService: ObservableObject {
         
         self.session = TangemSdk().makeSession(with: config,
                                                cardId: nil,
-                                               initialMessage: Message(header: "Scan the confirmation card"))
+                                               initialMessage: Message(header: "reset_codes_scan_confirmation_card".localized))
         
         session!.start(with: SignResetPinTokenCommand(resetPinCard: resetPinCard)) { result in
             switch result {
@@ -163,7 +163,7 @@ public class ResetPinService: ObservableObject {
         
         self.session = TangemSdk().makeSession(with: config,
                                                cardId: resetPinCard.cardId,
-                                               initialMessage: Message(header: "Scan card to reset user codes"))
+                                               initialMessage: Message(header: "reset_codes_scan_to_reset".localized))
         
         
         let task = ResetPinTask(confirmationCard: confirmationCard, accessCode: accessCodeUnwrapped, passcode: passcodeUnwrapped)

--- a/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
+++ b/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
@@ -91,9 +91,18 @@ public class ResetPinService: ObservableObject {
     }
     
     private func scanResetPinCard(resetCardId: String?, _ completion: @escaping CompletionResult<Void>) {
+        let userCodeType: UserCodeType
+        if repo.accessCode != nil {
+            userCodeType = .accessCode
+        } else if repo.passcode != nil {
+            userCodeType = .passcode
+        } else {
+            fatalError("Scan card called without the code specified")
+        }
+        
         self.session = TangemSdk().makeSession(with: config,
                                                cardId: resetCardId,
-                                               initialMessage: Message(header: "reset_codes_scan_first_card".localized))
+                                               initialMessage: Message(header: "reset_codes_scan_first_card".localized([userCodeType.name.lowercased()])))
         
         session!.start(with: GetResetPinTokenCommand()) { result in
             switch result {

--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -117,7 +117,7 @@ class SignCommand: Command {
     
     func sign(in session: CardSession, completion: @escaping CompletionResult<SignResponse>) {
         if numberOfChunks > 1 {
-            session.viewDelegate.showAlertMessage("Signing part \(currentChunkNumber + 1) of \(numberOfChunks)")
+            session.viewDelegate.showAlertMessage("sign_multiple_chunks_part".localized(["\(currentChunkNumber + 1)", "\(numberOfChunks)"]))
         }
         
         transceive(in: session) { result in

--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -117,7 +117,7 @@ class SignCommand: Command {
     
     func sign(in session: CardSession, completion: @escaping CompletionResult<SignResponse>) {
         if numberOfChunks > 1 {
-            session.viewDelegate.showAlertMessage("sign_multiple_chunks_part".localized(["\(currentChunkNumber + 1)", "\(numberOfChunks)"]))
+            session.viewDelegate.showAlertMessage("sign_multiple_chunks_part".localized([currentChunkNumber + 1, numberOfChunks]))
         }
         
         transceive(in: session) { result in


### PR DESCRIPTION
Текстовки для сервиса сброса кодов взял из андроида. "Scan the confirmation card" теперь поменялось на "Scan another linked card".

В табличку все добавил.