### PR TITLE
IOS-2715 Increase idle timeout

### DIFF
--- a/TangemSdk/TangemSdk/Common/NFC/NFCReader.swift
+++ b/TangemSdk/TangemSdk/Common/NFC/NFCReader.swift
@@ -447,7 +447,7 @@ extension NFCReader: NFCTagReaderSessionDelegate {
 extension NFCReader {
     enum Constants {
         static let tagTimeout = 20.0
-        static let idleTimeout = 2.0
+        static let idleTimeout = 4.0
         static let sessionTimeout = 60.0
         static let nfcStuckTimeout = 1.0
         static let retryCount = 20


### PR DESCRIPTION
2 секунд иногда становится слишком мало и  при активном SD, следующая команда не успевает отправиться в двухсекундное окно, происходит реконнект к тэгу за пределами 10-сек интервала и вылезает ошибка session invalidated unexpectedly. Увеличил пока idle таймаут в два раза, подумаю как сделать надежнее, опираясь на 10-сек окно реконнекта к тэгу.