### PR TITLE
IOS-2474 Shrinking User Code change header text

### DIFF
--- a/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
@@ -26,6 +26,8 @@ struct UserCodeHeaderView: View {
             
             Text(title)
                 .font(Font.system(size: 34).bold())
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
             
             Text(cardId)
                 .font(.system(size: 17))

--- a/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
@@ -25,7 +25,8 @@ struct UserCodeHeaderView: View {
             }.padding(.bottom, 16)
             
             Text(title)
-                .font(Font.system(size: 34).bold())
+                .font(Font.system(size: 24).bold())
+                .lineLimit(1)
             
             Text(cardId)
                 .font(.system(size: 17))

--- a/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
@@ -26,7 +26,6 @@ struct UserCodeHeaderView: View {
             
             Text(title)
                 .font(Font.system(size: 34).bold())
-                .fixedSize(horizontal: false, vertical: true)
             
             Text(cardId)
                 .font(.system(size: 17))

--- a/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/UserCodes/UserCodeHeaderView.swift
@@ -26,8 +26,7 @@ struct UserCodeHeaderView: View {
             
             Text(title)
                 .font(Font.system(size: 34).bold())
-                .minimumScaleFactor(0.7)
-                .lineLimit(1)
+                .fixedSize(horizontal: false, vertical: true)
             
             Text(cardId)
                 .font(.system(size: 17))


### PR DESCRIPTION
Была такая штука. 

<img width="412" alt="Screenshot 2022-12-28 at 12 57 50" src="https://user-images.githubusercontent.com/12209839/209794100-f334e652-64e0-4a39-bdc2-0b0b867b4e8a.png">

Стало так. На минике не сильно скукоживается.
![IMG_5431](https://user-images.githubusercontent.com/12209839/209794387-b2f22203-e294-45f2-989f-0951c2e913ac.PNG)

