### PR TITLE
IOS-3108 Do not release a remembered tag until the operation completion

### DIFF
--- a/TangemSdk/TangemSdk/Common/Core/CardSession.swift
+++ b/TangemSdk/TangemSdk/Common/Core/CardSession.swift
@@ -319,6 +319,8 @@ public class CardSession {
     
     /// We need to remember the tag for the duration of the command to be able to compare this tag with new one on tag from connected/lost events
     func rememberTag() {
+        guard case .tag = reader.tag.value else { return }
+        
         currentTag = reader.tag.value
     }
     

--- a/TangemSdk/TangemSdk/Operations/Command.swift
+++ b/TangemSdk/TangemSdk/Operations/Command.swift
@@ -98,11 +98,10 @@ extension Command {
             Log.apdu("C-APDU serialization finish".titleFormatted)
             
             transceive(apdu: commandApdu, in: session) { result in
-                session.releaseTag()
                 switch result {
                 case .success(let responseApdu):
                     do {
-                        
+                        session.releaseTag()
                         Log.apdu("R-APDU deserialization start".titleFormatted)
                         let responseData = try self.deserialize(with: session.environment, from: responseApdu)
                         Log.apdu("R-APDU deserialization finish".titleFormatted)
@@ -129,6 +128,7 @@ extension Command {
                             self.requestPin(.passcode, session, completion: completion)
                         } else { fallthrough }
                     default:
+                        session.releaseTag()
                         completion(.failure(error))
                     }
                 }
@@ -235,6 +235,7 @@ extension Command {
                     session.resume()
                     self.transceiveInternal(in: session, completion: completion)
                 case .failure(let error):
+                    session.releaseTag()
                     completion(.failure(error))
                 }
             }

--- a/TangemSdk/TangemSdk/Operations/Command.swift
+++ b/TangemSdk/TangemSdk/Operations/Command.swift
@@ -91,12 +91,12 @@ extension Command {
     
     private func transceiveInternal(in session: CardSession, completion: @escaping CompletionResult<CommandResponse>) {
         do {
-            session.rememberTag()
-            
             Log.apdu("C-APDU serialization start".titleFormatted)
             let commandApdu = try serialize(with: session.environment)
             Log.apdu("C-APDU serialization finish".titleFormatted)
-            
+
+            session.rememberTag()
+
             transceive(apdu: commandApdu, in: session) { result in
                 switch result {
                 case .success(let responseApdu):
@@ -134,6 +134,7 @@ extension Command {
                 }
             }
         } catch {
+            session.releaseTag()
             completion(.failure(error.toTangemSdkError()))
         }
     }


### PR DESCRIPTION
Мы не отслеживали ситуацию с прислонением неправильной карты после введения кода (или восстановления кода). Прилетала ошибка инвалид парамс. Я слегка подправил механизм отслеживания текущего тэга, который использовался для проверки карты при реконнектах. Теперь тэг запоминается и держится до тех пор, пока текущая команда не выполнится успешно или не зафейлится окончательно. Если требуется ввести код, то тэг не сбрасывается.