### PR TITLE
IOS-3226 Handle both codes resetting

### DIFF
--- a/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
+++ b/TangemSdk/TangemSdk/Operations/ResetCode/ResetPinService.swift
@@ -45,7 +45,10 @@ public class ResetPinService: ObservableObject {
         }
         
         repo.accessCode = code.sha256()
-        currentState = currentState.next()
+        
+        if currentState == .needCode {
+            currentState = currentState.next()
+        }
     }
     
     public func setPasscode(_ code: String) throws {
@@ -65,8 +68,12 @@ public class ResetPinService: ObservableObject {
                 throw TangemSdkError.passcodeTooShort
             }
         }
+
         repo.passcode = code.sha256()
-        currentState = currentState.next()
+
+        if currentState == .needCode {
+            currentState = currentState.next()
+        }
     }
     
     public func proceed(with resetCardId: String? = nil) {


### PR DESCRIPTION
Проблема возникала только при попытке сбросить оба кода низкоуровневого, через example, с отключением хэндлинга ошибок