### PR TITLE
IOS-3273 Keep the sdk logger configured from start

### DIFF
--- a/TangemSdk/TangemSdk/Common/Core/Config.swift
+++ b/TangemSdk/TangemSdk/Common/Core/Config.swift
@@ -42,7 +42,7 @@ public struct Config {
     public var cardIdDisplayFormat: CardIdDisplayFormat = .full
     
     /// Logger configuration
-    public var logConfig: Log.Config = .debug
+    public var logConfig: Log.Config = .default
     
     /// ScanTask or scanCard method in TangemSdk class will use this mode to attest the card
     public var attestationMode: AttestationTask.Mode = .normal

--- a/TangemSdk/TangemSdk/Common/Log/Log.swift
+++ b/TangemSdk/TangemSdk/Common/Log/Log.swift
@@ -11,16 +11,18 @@ import Foundation
 private let logger = Log()
 
 public class Log {
-    public static var config: Log.Config = .verbose {
+    public static var config: Config = .default {
         didSet {
             logger.logLevel = config.logLevel
             logger.loggers = config.loggers
         }
     }
     
-    private(set) var logLevel: [Log.Level] = []
+    private(set) var logLevel: [Log.Level] = Log.config.logLevel
     
-    private(set) var loggers: [TangemSdkLogger] = []
+    private(set) var loggers: [TangemSdkLogger] = Log.config.loggers
+
+    fileprivate init() {}
     
     public static func warning<T>(_ message: @autoclosure () -> T) {
         logger.logInternal(message(), level: .warning)
@@ -136,6 +138,8 @@ public extension Log {
         case verbose
         case custom(logLevel: [Log.Level],
                     loggers: [TangemSdkLogger] = [ConsoleLogger()])
+
+        static var `default`: Log.Config = .debug
         
         internal var logLevel: [Log.Level] {
             switch self {


### PR DESCRIPTION
Did set не вызывается при создании, поэтому логгер висел в нерабочем состоянии до первой инициализации сессии. Пофиксил, чтобы было ожидаемое поведение и логгер мог работать сразу.