### PR TITLE
IOS-3575 Added a way to show an image in the ReadView

### DIFF
--- a/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
+++ b/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
@@ -14,7 +14,7 @@ public class TangemSdkStyle: ObservableObject {
     public var colors: Colors = .default
     public var textSizes: TextSizes = .default
     public var indicatorWidth: Float = 12
-    public var readViewTag: ReadViewTag = .genericCard
+    public var nfcTag: NFCTag = .genericCard
     
     public static var `default`: TangemSdkStyle = .init()
 }
@@ -71,7 +71,7 @@ public extension TangemSdkStyle {
 @available(iOS 13.0, *)
 public extension TangemSdkStyle {
     /// Options for displaying different tags on the scanning screen
-    enum ReadViewTag {
+    enum NFCTag {
         /// Generic card provided by the SDK
         case genericCard
         

--- a/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
+++ b/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
@@ -21,8 +21,15 @@ public class TangemSdkStyle: ObservableObject {
 
 @available(iOS 13.0, *)
 public extension TangemSdkStyle {
+    /// Options for displaying different tags on the scanning screen
     enum ReadViewTag {
+        /// Generic card provided by the SDK
         case genericCard
+        
+        /// A custom image with a name `name` that resides in an Asset Catalog in a `bundle` bundle.
+        /// The image can be shifted vertically from the standard position by specifying `verticalOffset`.
+        /// Note that the width of the image will be limited to a certain size, while the height will be determined by the aspect ratio of the image.
+        /// The value of the width can be found in ReadView.swift and is 210 points at the time of the writing.
         case image(name: String, verticalOffset: Double, bundle: Bundle)
     }
 }

--- a/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
+++ b/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
@@ -14,8 +14,17 @@ public class TangemSdkStyle: ObservableObject {
     public var colors: Colors = .default
     public var textSizes: TextSizes = .default
     public var indicatorWidth: Float = 12
+    public var readViewTag: ReadViewTag = .genericCard
     
     public static var `default`: TangemSdkStyle = .init()
+}
+
+@available(iOS 13.0, *)
+public extension TangemSdkStyle {
+    enum ReadViewTag {
+        case genericCard
+        case image(name: String, verticalOffset: Double, bundle: Bundle)
+    }
 }
 
 @available(iOS 13.0, *)

--- a/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
+++ b/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
@@ -21,21 +21,6 @@ public class TangemSdkStyle: ObservableObject {
 
 @available(iOS 13.0, *)
 public extension TangemSdkStyle {
-    /// Options for displaying different tags on the scanning screen
-    enum ReadViewTag {
-        /// Generic card provided by the SDK
-        case genericCard
-        
-        /// A custom image with a name `name` that resides in an Asset Catalog in a `bundle` bundle.
-        /// The image can be shifted vertically from the standard position by specifying `verticalOffset`.
-        /// Note that the width of the image will be limited to a certain size, while the height will be determined by the aspect ratio of the image.
-        /// The value of the width can be found in ReadView.swift and is 210 points at the time of the writing.
-        case image(name: String, verticalOffset: Double, bundle: Bundle)
-    }
-}
-
-@available(iOS 13.0, *)
-public extension TangemSdkStyle {
     struct Colors {
         public var tint: Color = .blue
         
@@ -80,5 +65,20 @@ public extension TangemSdkStyle {
         public var indicatorLabel: CGFloat = 50
         
         public static var `default`: TextSizes = .init()
+    }
+}
+
+@available(iOS 13.0, *)
+public extension TangemSdkStyle {
+    /// Options for displaying different tags on the scanning screen
+    enum ReadViewTag {
+        /// Generic card provided by the SDK
+        case genericCard
+        
+        /// A custom image with a name `name` that resides in an Asset Catalog in a `bundle` bundle.
+        /// The image can be shifted vertically from the standard position by specifying `verticalOffset`.
+        /// Note that the width of the image will be limited to a certain size, while the height will be determined by the aspect ratio of the image.
+        /// The value of the width can be found in ReadView.swift and is 210 points at the time of the writing.
+        case image(name: String, verticalOffset: Double, bundle: Bundle)
     }
 }

--- a/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
+++ b/TangemSdk/TangemSdk/UI/TangemSdkStyle.swift
@@ -75,10 +75,10 @@ public extension TangemSdkStyle {
         /// Generic card provided by the SDK
         case genericCard
         
-        /// A custom image with a name `name` that resides in an Asset Catalog in a `bundle` bundle.
+        /// A custom tag made out of an UIImage instance.
         /// The image can be shifted vertically from the standard position by specifying `verticalOffset`.
         /// Note that the width of the image will be limited to a certain size, while the height will be determined by the aspect ratio of the image.
         /// The value of the width can be found in ReadView.swift and is 210 points at the time of the writing.
-        case image(name: String, verticalOffset: Double, bundle: Bundle)
+        case image(uiImage: UIImage, verticalOffset: Double)
     }
 }

--- a/TangemSdk/TangemSdk/UI/Views/Scan/CardView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Scan/CardView.swift
@@ -17,6 +17,7 @@ struct CardView: View {
         RoundedRectangle(cornerRadius: 10)
             .fill(cardColor)
             .overlay(overlay)
+            .aspectRatio(CGSize(width: 210, height: 130), contentMode: .fit)
     }
     
     @ViewBuilder

--- a/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
@@ -42,7 +42,7 @@ struct ReadView: View {
     
     @ViewBuilder
     private var tagView: some View {
-        switch style.readViewTag {
+        switch style.nfcTag {
         case .genericCard:
             CardView(cardColor: style.colors.cardColor, starsColor: style.colors.starsColor)
         case .image(let name, let verticalOffset, let bundle):

--- a/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
@@ -20,10 +20,9 @@ struct ReadView: View {
                 NFCFieldView(isAnimationOn: true)
                     .frame(width: 240, height: 240)
                     .offset(y: -160)
-                
-                CardView(cardColor: style.colors.cardColor,
-                         starsColor: style.colors.starsColor)
-                    .frame(width: 210, height: 130)
+
+                tagView
+                    .frame(minWidth: 210, maxWidth: 210)
                     .offset(cardOffset)
                     .animation(Animation
                                 .easeInOut(duration: 1)
@@ -38,6 +37,19 @@ struct ReadView: View {
         }
         .onAppear {
             cardOffset.width = 0
+        }
+    }
+    
+    @ViewBuilder
+    private var tagView: some View {
+        switch style.readViewTag {
+        case .genericCard:
+            CardView(cardColor: style.colors.cardColor, starsColor: style.colors.starsColor)
+        case .image(let name, let verticalOffset, let bundle):
+            Image(name, bundle: bundle)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .offset(y: verticalOffset)
         }
     }
 }

--- a/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
@@ -45,8 +45,8 @@ struct ReadView: View {
         switch style.nfcTag {
         case .genericCard:
             CardView(cardColor: style.colors.cardColor, starsColor: style.colors.starsColor)
-        case .image(let name, let verticalOffset, let bundle):
-            Image(name, bundle: bundle)
+        case .image(let uiImage, let verticalOffset):
+            Image(uiImage: uiImage)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .offset(y: verticalOffset)

--- a/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
+++ b/TangemSdk/TangemSdk/UI/Views/Scan/ReadView.swift
@@ -20,7 +20,7 @@ struct ReadView: View {
                 NFCFieldView(isAnimationOn: true)
                     .frame(width: 240, height: 240)
                     .offset(y: -160)
-
+                
                 tagView
                     .frame(minWidth: 210, maxWidth: 210)
                     .offset(cardOffset)


### PR DESCRIPTION
In order to show an image on the scanning screen you need to set the value of the default tag style in TangemSdkStyle to e.g. 

```
.image(uiImage: ..., verticalOffset: 0)
```

- where "uiimage" is the image you want to display, a UIImage built however you like (asset catalog, base64 binary, etc)
- `verticalOffset` is the distance that the image will be shifted vertically from the standard position