### PR TITLE
Return cardId inside backupFailedNotEmptyWallets

### DIFF
--- a/TangemSdk/TangemSdk/Common/Core/TangemSdkError.swift
+++ b/TangemSdk/TangemSdk/Common/Core/TangemSdkError.swift
@@ -260,7 +260,7 @@ public enum TangemSdkError: Error, LocalizedError, Encodable {
     case backupCardRequired
     case noBackupDataForCard
     case backupFailedEmptyWallets
-    case backupFailedNotEmptyWallets
+    case backupFailedNotEmptyWallets(cardId: String)
     case certificateSignatureRequired
     case issuerSignatureLoadingFailed
     case accessCodeOrPasscodeRequired

--- a/TangemSdk/TangemSdk/Operations/Backup/LinkPrimaryCardCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/LinkPrimaryCardCommand.swift
@@ -48,7 +48,7 @@ final class LinkPrimaryCardCommand: Command {
         }
         
         if !card.wallets.isEmpty {
-            return .backupFailedNotEmptyWallets
+            return .backupFailedNotEmptyWallets(cardId: card.cardId)
         }
         
         return nil

--- a/TangemSdk/TangemSdk/Operations/Backup/StartBackupCardLinkingCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/StartBackupCardLinkingCommand.swift
@@ -37,7 +37,7 @@ final class StartBackupCardLinkingCommand: Command {
         }
         
         if !card.wallets.isEmpty {
-            return .backupFailedNotEmptyWallets
+            return .backupFailedNotEmptyWallets(cardId: card.cardId)
         }
         
         return nil

--- a/TangemSdk/TangemSdk/Operations/Backup/WriteBackupDataCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/WriteBackupDataCommand.swift
@@ -48,7 +48,7 @@ final class WriteBackupDataCommand: Command {
         }
         
         if !card.wallets.isEmpty {
-            return .backupFailedNotEmptyWallets
+            return .backupFailedNotEmptyWallets(cardId: card.cardId)
         }
 
         return nil


### PR DESCRIPTION
Для того, чтобы ограничить сброс конкретной картой в случае этой ошибки