### PR TITLE
Impement key import for BLS

### DIFF
--- a/TangemSdk/TangemSdk.xcodeproj/project.pbxproj
+++ b/TangemSdk/TangemSdk.xcodeproj/project.pbxproj
@@ -274,6 +274,12 @@
 		DC7254902A03E20A0003FE1B /* DerivedKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72548F2A03E20A0003FE1B /* DerivedKeys.swift */; };
 		DC8B0E3F286F221D009D64F7 /* BiometricsUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8B0E3E286F221D009D64F7 /* BiometricsUtil.swift */; };
 		DCA9706628E35EAD0046E62E /* GenerateOTPCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA9706528E35EAD0046E62E /* GenerateOTPCommand.swift */; };
+		DCB5A4E02A1F969F0021E12D /* HKDFUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4DF2A1F969F0021E12D /* HKDFUtil.swift */; };
+		DCB5A4E32A1FAB330021E12D /* BLSUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4E22A1FAB330021E12D /* BLSUtils.swift */; };
+		DCB5A4E52A1FAC190021E12D /* BLSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4E42A1FAC190021E12D /* BLSTests.swift */; };
+		DCB5A4E72A1FBA8B0021E12D /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4E62A1FBA8B0021E12D /* BigInt.swift */; };
+		DCB5A4E92A20EB1F0021E12D /* HKDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4E82A20EB1F0021E12D /* HKDFTests.swift */; };
+		DCB5A4EB2A20F47B0021E12D /* MasterKeyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB5A4EA2A20F47B0021E12D /* MasterKeyFactory.swift */; };
 		DCC0A21129D3146100C45B13 /* SetUserSettingsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC0A21029D3146100C45B13 /* SetUserSettingsCommand.swift */; };
 		DCC0A21429D3201300C45B13 /* SetUserCodeRecoveryAllowedTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC0A21329D3201300C45B13 /* SetUserCodeRecoveryAllowedTask.swift */; };
 		DCC0A21629D3216100C45B13 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC0A21529D3216100C45B13 /* UserSettings.swift */; };
@@ -641,6 +647,12 @@
 		DC72548F2A03E20A0003FE1B /* DerivedKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivedKeys.swift; sourceTree = "<group>"; };
 		DC8B0E3E286F221D009D64F7 /* BiometricsUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricsUtil.swift; sourceTree = "<group>"; };
 		DCA9706528E35EAD0046E62E /* GenerateOTPCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateOTPCommand.swift; sourceTree = "<group>"; };
+		DCB5A4DF2A1F969F0021E12D /* HKDFUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKDFUtil.swift; sourceTree = "<group>"; };
+		DCB5A4E22A1FAB330021E12D /* BLSUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLSUtils.swift; sourceTree = "<group>"; };
+		DCB5A4E42A1FAC190021E12D /* BLSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLSTests.swift; sourceTree = "<group>"; };
+		DCB5A4E62A1FBA8B0021E12D /* BigInt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigInt.swift; sourceTree = "<group>"; };
+		DCB5A4E82A20EB1F0021E12D /* HKDFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKDFTests.swift; sourceTree = "<group>"; };
+		DCB5A4EA2A20F47B0021E12D /* MasterKeyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterKeyFactory.swift; sourceTree = "<group>"; };
 		DCC0A21029D3146100C45B13 /* SetUserSettingsCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUserSettingsCommand.swift; sourceTree = "<group>"; };
 		DCC0A21329D3201300C45B13 /* SetUserCodeRecoveryAllowedTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUserCodeRecoveryAllowedTask.swift; sourceTree = "<group>"; };
 		DCC0A21529D3216100C45B13 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
@@ -1237,6 +1249,8 @@
 				5D6F51FD265845D5007CD7E2 /* JSONRPCTests.swift */,
 				5D170AF226B46DAC000D4F36 /* HDWalletTests.swift */,
 				DC4E442829BF42630088617C /* Base58Tests.swift */,
+				DCB5A4E42A1FAC190021E12D /* BLSTests.swift */,
+				DCB5A4E82A20EB1F0021E12D /* HKDFTests.swift */,
 			);
 			path = TangemSdkTests;
 			sourceTree = "<group>";
@@ -1291,6 +1305,7 @@
 				5D379C2C268FA53D00C7F473 /* KeyPair.swift */,
 				5D379C2E268FA57500C7F473 /* UserCode.swift */,
 				5DE7DD2F2695DCD300472205 /* CardFilter.swift */,
+				DCB5A4EA2A20F47B0021E12D /* MasterKeyFactory.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1298,6 +1313,7 @@
 		5DFFC1A2234DC969001C2F35 /* Crypto */ = {
 			isa = PBXGroup;
 			children = (
+				DCB5A4E12A1FAB190021E12D /* BLS */,
 				DC59CB0129AF582800EC14E1 /* BIP39 */,
 				5D170AEF26B42C88000D4F36 /* HDWallet */,
 				5D83F36E247EC275005E7A35 /* secp256k1 */,
@@ -1468,6 +1484,16 @@
 				DC1244B429B60E480037BC05 /* english.txt */,
 			);
 			path = Wordlists;
+			sourceTree = "<group>";
+		};
+		DCB5A4E12A1FAB190021E12D /* BLS */ = {
+			isa = PBXGroup;
+			children = (
+				DCB5A4DF2A1F969F0021E12D /* HKDFUtil.swift */,
+				DCB5A4E22A1FAB330021E12D /* BLSUtils.swift */,
+				DCB5A4E62A1FBA8B0021E12D /* BigInt.swift */,
+			);
+			path = BLS;
 			sourceTree = "<group>";
 		};
 		DCC0A21229D31FDD00C45B13 /* UserSettings */ = {
@@ -1874,6 +1900,7 @@
 				5D908C6126A75DB700270FA3 /* ReadView.swift in Sources */,
 				5D0243BE26CACACD00B76F37 /* IndicatorView.swift in Sources */,
 				5D1D945C2722FD7400FD6DAB /* CreateWalletTask.swift in Sources */,
+				DCB5A4E02A1F969F0021E12D /* HKDFUtil.swift in Sources */,
 				5DE59F2D23D96FE500312DA4 /* TerminalKeysService.swift in Sources */,
 				DCC0A21629D3216100C45B13 /* UserSettings.swift in Sources */,
 				DC59CB0A29AF6F9C00EC14E1 /* EntropyLength.swift in Sources */,
@@ -1884,6 +1911,7 @@
 				B0390F8325658F3B0061E5ED /* ProductMask.swift in Sources */,
 				5D23C42426CE749F00A1A280 /* FloatingTextField.swift in Sources */,
 				B00BC5C4260B80E600F0647D /* Track.swift in Sources */,
+				DCB5A4E32A1FAB330021E12D /* BLSUtils.swift in Sources */,
 				5D14947F2686458100C0D923 /* GenericPasswordConvertible.swift in Sources */,
 				5D86CBDB24A1102D00FB5BA7 /* Issuer.swift in Sources */,
 				DC1244C729B776D40037BC05 /* ExtendedPrivateKey.swift in Sources */,
@@ -1924,6 +1952,7 @@
 				5D6508232672755600A8D45B /* Wallet.swift in Sources */,
 				B0918FA625341ADB001E8B34 /* WriteFilesTask.swift in Sources */,
 				B0EC6508260110CC0088F03D /* ReadWalletCommand.swift in Sources */,
+				DCB5A4EB2A20F47B0021E12D /* MasterKeyFactory.swift in Sources */,
 				B0B398162539DC4700573220 /* DeleteAllFilesTask.swift in Sources */,
 				5DFCAF57258CB9FF00CD237F /* CardIdFormatter.swift in Sources */,
 				B0A9448525654BBC00A7958E /* FirmwareVersion.swift in Sources */,
@@ -1952,6 +1981,7 @@
 				5D539ECB276CDD8600AB8B53 /* DeriveMultipleWalletPublicKeysTask.swift in Sources */,
 				DA6C752A292682650070EEFD /* LAContext+.swift in Sources */,
 				DCC6A64829D212E8007BA5B7 /* GetEntropyCommand.swift in Sources */,
+				DCB5A4E72A1FBA8B0021E12D /* BigInt.swift in Sources */,
 				5DE43A6026D511CE00ECA36A /* LinkBackupCardsCommand.swift in Sources */,
 				5D0A6C5D2428CF3C0094FA83 /* Error+.swift in Sources */,
 				5D270F2726A020DA00D2EDC1 /* WalletDataDeserializer.swift in Sources */,
@@ -2080,12 +2110,14 @@
 				5DA7942A236C64D100B33DB5 /* IntUtilsTests.swift in Sources */,
 				5DA80CA9231D247A00A50A10 /* CryptoUtilsTests.swift in Sources */,
 				5D713B2D236C3F6400E4F6FC /* StringUtilsTest.swift in Sources */,
+				DCB5A4E52A1FAC190021E12D /* BLSTests.swift in Sources */,
 				DC1244C929B778750037BC05 /* BIP32Tests.swift in Sources */,
 				DC1244E429BB806E0037BC05 /* WIFTests.swift in Sources */,
 				DC1244B929B610550037BC05 /* BIP39Tests.swift in Sources */,
 				5DD127A224F3D1A0009ACA29 /* JsonTests.swift in Sources */,
 				DC1244DC29BB66840037BC05 /* ExtendedKeyTests.swift in Sources */,
 				5DAD449E236B2435006C38F8 /* DataExtensionTests.swift in Sources */,
+				DCB5A4E92A20EB1F0021E12D /* HKDFTests.swift in Sources */,
 				5D6795B2237AEFB60075A330 /* ApduTests.swift in Sources */,
 				5D6F51FE265845D5007CD7E2 /* JSONRPCTests.swift in Sources */,
 				5D713B2F236C53E300E4F6FC /* ByteUtilsTest.swift in Sources */,

--- a/TangemSdk/TangemSdk/Common/MasterKeyFactory.swift
+++ b/TangemSdk/TangemSdk/Common/MasterKeyFactory.swift
@@ -1,0 +1,22 @@
+//
+//  MasterKeyFactory.swift
+//  TangemSdk
+//
+//  Created by Alexander Osokin on 26.05.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+struct MasterKeyFactory {
+    func makePrivateKey(from seed: Data, curve: EllipticCurve) throws -> ExtendedPrivateKey {
+        switch curve {
+        case .bls12381_G2, .bls12381_G2_AUG, .bls12381_G2_POP:
+            let keyData = try BLSUtils().generateKey(inputKeyMaterial: seed)
+            return ExtendedPrivateKey(privateKey: keyData, chainCode: Data())
+        case .secp256k1, .secp256r1, .bip0340, .ed25519:
+            return try BIP32().makeMasterKey(from: seed, curve: curve)
+        }
+    }
+}

--- a/TangemSdk/TangemSdk/Common/Services/Secure/GenericPasswordConvertible.swift
+++ b/TangemSdk/TangemSdk/Common/Services/Secure/GenericPasswordConvertible.swift
@@ -39,7 +39,7 @@ extension SecureEnclave.P256.Signing.PrivateKey: GenericPasswordConvertible {
     }
 }
 
-extension ContiguousBytes {
+fileprivate extension ContiguousBytes {
     /// A Data instance created safely from the contiguous bytes without making any copies.
     var dataRepresentation: Data {
         return self.withUnsafeBytes { bytes in
@@ -48,4 +48,3 @@ extension ContiguousBytes {
         }
     }
 }
-

--- a/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
@@ -23,8 +23,8 @@ struct BLSUtils {
         let inputKeyMaterialData = inputKeyMaterial + Data([0x00])
         let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: inputKeyMaterialData, salt: salt)
 
-        let info = keyInfo ?? Data() + Constants.count.bytes2
-        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: Constants.count)
+        let info = keyInfo ?? Data() + Constants.okmCount.bytes2
+        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: Constants.okmCount)
 
         guard let intKey = BigInt(okm.hexString, radix: 16) else {
             throw BLSError.keyGenerationFailed
@@ -51,11 +51,11 @@ extension BLSUtils {
         /// Actual version of  keygen algorithm
         static let salt: Data = saltPreV4.getSha256()
         
-        /// l, Calculated as ceil((3 * ceil(log2(r))) / 16). where r is s the order of the BLS 12-381
-        fileprivate static let count = 48
+        /// L, Calculated as ceil((3 * ceil(log2(r))) / 16). where r is s the order of the BLS 12-381
+        fileprivate static let okmCount: Int = 48
 
         /// r, defined in  https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04
-        fileprivate static let curveOrder = BigInt("52435875175126190479447740508185965837690552500527637822603658699938581184513", radix: 10)!
+        fileprivate static let curveOrder: BigInt = .init("52435875175126190479447740508185965837690552500527637822603658699938581184513", radix: 10)!
     }
 
     enum BLSError: Error {

--- a/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
@@ -1,0 +1,68 @@
+//
+//  BLSUtils.swift
+//  TangemSdk
+//
+//  Created by Alexander Osokin on 25.05.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+
+@available(iOS 13.0, *)
+struct BLSUtils {
+    /// hkdf_mod_r() implementaion (KeyGen)
+    /// https://eips.ethereum.org/EIPS/eip-2333#hkdf_mod_r-1
+    /// https://www.ietf.org/archive/id/draft-irtf-cfrg-bls-signature-05.html#name-keygen
+    /// - Parameters:
+    ///   - inputKeyMaterial: input keying material
+    ///   - salt: salt value
+    ///   - keyInfo: optional context and application specific information (can be a zero-length octet string)
+    /// - Returns: Generated key
+    func generateKey(inputKeyMaterial: Data, salt: Data = Constants.salt, keyInfo: Data? = nil) throws -> Data {
+        let inputKeyMaterialData = inputKeyMaterial + Data([0x00])
+        let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: inputKeyMaterialData, salt: salt)
+
+        let info = keyInfo ?? Data() + Constants.count.bytes2
+        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: Constants.count)
+        let keyData = okm.dataRepresentation
+
+        guard let intKey = BigInt(keyData.hexString, radix: 16) else {
+            throw BLSError.keyGenerationFailed
+        }
+
+        let sk  = intKey % Constants.curveOrder
+        if sk != 0 {
+            guard let serializedKey = sk.decimalString.data(using: .utf8) else {
+                throw BLSError.keyGenerationFailed
+            }
+
+            return serializedKey
+        }
+
+        let salt = salt.getSha256()
+
+        return try generateKey(inputKeyMaterial: inputKeyMaterial, salt: salt, keyInfo: keyInfo)
+    }
+}
+
+@available(iOS 13.0, *)
+extension BLSUtils {
+    enum Constants {
+        /// Version of  keygen algorithm prior to number 4
+        static let saltPreV4: Data = "BLS-SIG-KEYGEN-SALT-".data(using: .utf8)!
+
+        /// Actual version of  keygen algorithm
+        static let salt: Data = saltPreV4.getSha256()
+        
+        /// l, Calculated as ceil((3 * ceil(log2(r))) / 16). where r is s the order of the BLS 12-381
+        fileprivate static let count = 48
+
+        /// r, defined in  https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04
+        fileprivate static let curveOrder = BigInt("52435875175126190479447740508185965837690552500527637822603658699938581184513", radix: 10)!
+    }
+
+    enum BLSError: Error {
+        case keyGenerationFailed
+    }
+}

--- a/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/BLSUtils.swift
@@ -25,23 +25,19 @@ struct BLSUtils {
 
         let info = keyInfo ?? Data() + Constants.count.bytes2
         let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: Constants.count)
-        let keyData = okm.dataRepresentation
 
-        guard let intKey = BigInt(keyData.hexString, radix: 16) else {
+        guard let intKey = BigInt(okm.hexString, radix: 16) else {
             throw BLSError.keyGenerationFailed
         }
 
         let sk  = intKey % Constants.curveOrder
+        
         if sk != 0 {
-            guard let serializedKey = sk.decimalString.data(using: .utf8) else {
-                throw BLSError.keyGenerationFailed
-            }
-
-            return serializedKey
+            return Data(hexString: sk.hexString)
         }
 
         let salt = salt.getSha256()
-
+        
         return try generateKey(inputKeyMaterial: inputKeyMaterial, salt: salt, keyInfo: keyInfo)
     }
 }

--- a/TangemSdk/TangemSdk/Crypto/BLS/BigInt.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/BigInt.swift
@@ -1,0 +1,1431 @@
+//===--- BigInt.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+typealias BigInt = _BigInt<UInt8>
+
+extension FixedWidthInteger {
+    /// Returns the high and low parts of a potentially overflowing addition.
+    func addingFullWidth(_ other: Self) ->
+    (high: Self, low: Self) {
+        let sum = self.addingReportingOverflow(other)
+        return (sum.overflow ? 1 : 0, sum.partialValue)
+    }
+
+    /// Returns the high and low parts of two seqeuential potentially overflowing
+    /// additions.
+    static func addingFullWidth(_ x: Self, _ y: Self, _ z: Self) ->
+    (high: Self, low: Self) {
+        let xy = x.addingReportingOverflow(y)
+        let xyz = xy.partialValue.addingReportingOverflow(z)
+        let high: Self = (xy.overflow ? 1 : 0) +
+        (xyz.overflow ? 1 : 0)
+        return (high, xyz.partialValue)
+    }
+
+    /// Returns a tuple containing the value that would be borrowed from a higher
+    /// place and the partial difference of this value and `rhs`.
+    func subtractingWithBorrow(_ rhs: Self) ->
+    (borrow: Self, partialValue: Self) {
+        let difference = subtractingReportingOverflow(rhs)
+        return (difference.overflow ? 1 : 0, difference.partialValue)
+    }
+
+    /// Returns a tuple containing the value that would be borrowed from a higher
+    /// place and the partial value of `x` and `y` subtracted from this value.
+    func subtractingWithBorrow(_ x: Self, _ y: Self) ->
+    (borrow: Self, partialValue: Self) {
+        let firstDifference = subtractingReportingOverflow(x)
+        let secondDifference =
+        firstDifference.partialValue.subtractingReportingOverflow(y)
+        let borrow: Self = (firstDifference.overflow ? 1 : 0) +
+        (secondDifference.overflow ? 1 : 0)
+        return (borrow, secondDifference.partialValue)
+    }
+}
+
+//===--- BigInt -----------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+/// A dynamically-sized signed integer.
+///
+/// The `_BigInt` type is fully generic on the size of its "word" -- the
+/// `BigInt` alias uses the system's word-sized `UInt` as its word type, but
+/// any word size should work properly.
+struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
+    BinaryInteger, SignedInteger, CustomStringConvertible,
+    CustomDebugStringConvertible
+where Word.Magnitude == Word
+{
+
+    /// The binary representation of the value's magnitude, with the least
+    /// significant word at index `0`.
+    ///
+    /// - `_data` has no trailing zero elements
+    /// - If `self == 0`, then `isNegative == false` and `_data == []`
+    internal var _data: [Word] = []
+
+    /// A Boolean value indicating whether this instance is negative.
+    private(set) var isNegative = false
+
+    /// A Boolean value indicating whether this instance is equal to zero.
+    var isZero: Bool {
+        return _data.isEmpty
+    }
+
+    //===--- Numeric initializers -------------------------------------------===//
+
+    /// Creates a new instance equal to zero.
+    init() { }
+
+    /// Creates a new instance using `_data` as the data collection.
+    init<C: Collection>(_ _data: C) where C.Iterator.Element == Word {
+        self._data = Array(_data)
+        _standardize()
+    }
+
+    init(integerLiteral value: Int) {
+        self.init(value)
+    }
+
+    init<T : BinaryInteger>(_ source: T) {
+        var source = source
+        if source < 0 as T {
+            if source.bitWidth <= UInt64.bitWidth {
+                let sourceMag = Int(truncatingIfNeeded: source).magnitude
+                self = _BigInt(sourceMag)
+                self.isNegative = true
+                return
+            } else {
+                // Have to kind of assume that we're working with another BigInt here
+                self.isNegative = true
+                source *= -1
+            }
+        }
+
+        // FIXME: This is broken on 32-bit arch w/ Word = UInt64
+        let wordRatio = UInt.bitWidth / Word.bitWidth
+        assert(wordRatio != 0)
+        for var sourceWord in source.words {
+            for _ in 0..<wordRatio {
+                _data.append(Word(truncatingIfNeeded: sourceWord))
+                sourceWord >>= Word.bitWidth
+            }
+        }
+        _standardize()
+    }
+
+    init?<T : BinaryInteger>(exactly source: T) {
+        self.init(source)
+    }
+
+    init<T : BinaryInteger>(truncatingIfNeeded source: T) {
+        self.init(source)
+    }
+
+    init<T : BinaryInteger>(clamping source: T) {
+        self.init(source)
+    }
+
+    init<T : BinaryFloatingPoint>(_ source: T) {
+        fatalError("Not implemented")
+    }
+
+    init?<T : BinaryFloatingPoint>(exactly source: T) {
+        fatalError("Not implemented")
+    }
+
+    /// Returns a randomly-generated word.
+    static func _randomWord() -> Word {
+        // This handles up to a 64-bit word
+        if Word.bitWidth > UInt32.bitWidth {
+            return Word(UInt32.random(in: 0...UInt32.max)) << 32 | Word(UInt32.random(in: 0...UInt32.max))
+        } else {
+            return Word(truncatingIfNeeded: UInt32.random(in: 0...UInt32.max))
+        }
+    }
+
+    /// Creates a new instance whose magnitude has `randomBits` bits of random
+    /// data. The sign of the new value is randomly selected.
+    init(randomBits: Int) {
+        let (words, extraBits) =
+        randomBits.quotientAndRemainder(dividingBy: Word.bitWidth)
+
+        // Get the bits for any full words.
+        self._data = (0..<words).map({ _ in _BigInt._randomWord() })
+
+        // Get another random number - the highest bit will determine the sign,
+        // while the lower `Word.bitWidth - 1` bits are available for any leftover
+        // bits in `randomBits`.
+        let word = _BigInt._randomWord()
+        if extraBits != 0 {
+            let mask = ~((~0 as Word) << Word(extraBits))
+            _data.append(word & mask)
+        }
+        isNegative = word & ~(~0 >> 1) == 0
+
+        _standardize()
+    }
+
+    //===--- Private methods ------------------------------------------------===//
+
+    /// Standardizes this instance after mutation, removing trailing zeros
+    /// and making sure zero is nonnegative. Calling this method satisfies the
+    /// two invariants.
+    mutating func _standardize(source: String = #function) {
+        defer { _checkInvariants(source: source + " >> _standardize()") }
+        while _data.last == 0 {
+            _data.removeLast()
+        }
+        // Zero is never negative.
+        isNegative = isNegative && _data.count != 0
+    }
+
+    /// Checks and asserts on invariants -- all invariants must be satisfied
+    /// at the end of every mutating method.
+    ///
+    /// - `_data` has no trailing zero elements
+    /// - If `self == 0`, then `isNegative == false`
+    func _checkInvariants(source: String = #function) {
+        if _data.isEmpty {
+            assert(isNegative == false,
+                   "\(source): isNegative with zero length _data")
+        }
+        assert(_data.last != 0, "\(source): extra zeroes on _data")
+    }
+
+    //===--- Word-based arithmetic ------------------------------------------===//
+
+    mutating func _unsignedAdd(_ rhs: Word) {
+        defer { _standardize() }
+
+        // Quick return if `rhs == 0`
+        guard rhs != 0 else { return }
+
+        // Quick return if `self == 0`
+        if isZero {
+            _data.append(rhs)
+            return
+        }
+
+        // Add `rhs` to the first word, catching any carry.
+        var carry: Word
+        (carry, _data[0]) = _data[0].addingFullWidth(rhs)
+
+        // Handle any additional carries
+        for i in 1..<_data.count {
+            // No more action needed if there's nothing to carry
+            if carry == 0 { break }
+            (carry, _data[i]) = _data[i].addingFullWidth(carry)
+        }
+
+        // If there's any carry left, add it now
+        if carry != 0 {
+            _data.append(1)
+        }
+    }
+
+    /// Subtracts `rhs` from this instance, ignoring the sign.
+    ///
+    /// - Precondition: `rhs <= self.magnitude`
+    mutating func _unsignedSubtract(_ rhs: Word) {
+        precondition(_data.count > 1 || _data[0] > rhs)
+
+        // Quick return if `rhs == 0`
+        guard rhs != 0 else { return }
+
+        // If `isZero == true`, then `rhs` must also be zero.
+        precondition(!isZero)
+
+        var carry: Word
+        (carry, _data[0]) = _data[0].subtractingWithBorrow(rhs)
+
+        for i in 1..<_data.count {
+            // No more action needed if there's nothing to carry
+            if carry == 0 { break }
+            (carry, _data[i]) = _data[i].subtractingWithBorrow(carry)
+        }
+        assert(carry == 0)
+
+        _standardize()
+    }
+
+    /// Adds `rhs` to this instance.
+    mutating func add(_ rhs: Word) {
+        if isNegative {
+            // If _data only contains one word and `rhs` is greater, swap them,
+            // make self positive and continue with unsigned subtraction.
+            var rhs = rhs
+            if _data.count == 1 && _data[0] < rhs {
+                swap(&rhs, &_data[0])
+                isNegative = false
+            }
+            _unsignedSubtract(rhs)
+        } else {   // positive or zero
+            _unsignedAdd(rhs)
+        }
+    }
+
+    /// Subtracts `rhs` from this instance.
+    mutating func subtract(_ rhs: Word) {
+        guard rhs != 0 else { return }
+
+        if isNegative {
+            _unsignedAdd(rhs)
+        } else if isZero {
+            isNegative = true
+            _data.append(rhs)
+        } else {
+            var rhs = rhs
+            if _data.count == 1 && _data[0] < rhs {
+                swap(&rhs, &_data[0])
+                isNegative = true
+            }
+            _unsignedSubtract(rhs)
+        }
+    }
+
+    /// Multiplies this instance by `rhs`.
+    mutating func multiply(by rhs: Word) {
+        // If either `self` or `rhs` is zero, the result is zero.
+        guard !isZero && rhs != 0 else {
+            self = 0
+            return
+        }
+
+        // If `rhs` is a power of two, can just left shift `self`.
+        let rhsLSB = rhs.trailingZeroBitCount
+        if rhs >> rhsLSB == 1 {
+            self <<= rhsLSB
+            return
+        }
+
+        var carry: Word = 0
+        for i in 0..<_data.count {
+            let product = _data[i].multipliedFullWidth(by: rhs)
+            (carry, _data[i]) = product.low.addingFullWidth(carry)
+            carry = carry &+ product.high
+        }
+
+        // Add the leftover carry
+        if carry != 0 {
+            _data.append(carry)
+        }
+        _standardize()
+    }
+
+    /// Divides this instance by `rhs`, returning the remainder.
+    @discardableResult
+    mutating func divide(by rhs: Word) -> Word {
+        precondition(rhs != 0, "divide by zero")
+
+        // No-op if `rhs == 1` or `self == 0`.
+        if rhs == 1 || isZero {
+            return 0
+        }
+
+        // If `rhs` is a power of two, can just right shift `self`.
+        let rhsLSB = rhs.trailingZeroBitCount
+        if rhs >> rhsLSB == 1 {
+            defer { self >>= rhsLSB }
+            return _data[0] & ~(~0 << rhsLSB)
+        }
+
+        var carry: Word = 0
+        for i in (0..<_data.count).reversed() {
+            let lhs = (high: carry, low: _data[i])
+            (_data[i], carry) = rhs.dividingFullWidth(lhs)
+        }
+
+        _standardize()
+        return carry
+    }
+
+    //===--- Numeric --------------------------------------------------------===//
+
+    typealias Magnitude = _BigInt
+
+    var magnitude: _BigInt {
+        var result = self
+        result.isNegative = false
+        return result
+    }
+
+    /// Adds `rhs` to this instance, ignoring any signs.
+    mutating func _unsignedAdd(_ rhs: _BigInt) {
+        defer { _checkInvariants() }
+
+        let commonCount = Swift.min(_data.count, rhs._data.count)
+        let maxCount = Swift.max(_data.count, rhs._data.count)
+        _data.reserveCapacity(maxCount)
+
+        // Add the words up to the common count, carrying any overflows
+        var carry: Word = 0
+        for i in 0..<commonCount {
+            (carry, _data[i]) = Word.addingFullWidth(_data[i], rhs._data[i], carry)
+        }
+
+        // If there are leftover words in `self`, just need to handle any carries
+        if _data.count > rhs._data.count {
+            for i in commonCount..<maxCount {
+                // No more action needed if there's nothing to carry
+                if carry == 0 { break }
+                (carry, _data[i]) = _data[i].addingFullWidth(carry)
+            }
+
+            // If there are leftover words in `rhs`, need to copy to `self` with carries
+        } else if _data.count < rhs._data.count {
+            for i in commonCount..<maxCount {
+                // Append remaining words if nothing to carry
+                if carry == 0 {
+                    _data.append(contentsOf: rhs._data.suffix(from: i))
+                    break
+                }
+                let sum: Word
+                (carry, sum) = rhs._data[i].addingFullWidth(carry)
+                _data.append(sum)
+            }
+        }
+
+        // If there's any carry left, add it now
+        if carry != 0 {
+            _data.append(1)
+        }
+    }
+
+    /// Subtracts `rhs` from this instance, ignoring the sign.
+    ///
+    /// - Precondition: `rhs.magnitude <= self.magnitude` (unchecked)
+    /// - Precondition: `rhs._data.count <= self._data.count`
+    mutating func _unsignedSubtract(_ rhs: _BigInt) {
+        precondition(rhs._data.count <= _data.count)
+
+        var carry: Word = 0
+        for i in 0..<rhs._data.count {
+            (carry, _data[i]) = _data[i].subtractingWithBorrow(rhs._data[i], carry)
+        }
+
+        for i in rhs._data.count..<_data.count {
+            // No more action needed if there's nothing to carry
+            if carry == 0 { break }
+            (carry, _data[i]) = _data[i].subtractingWithBorrow(carry)
+        }
+        assert(carry == 0)
+
+        _standardize()
+    }
+
+    static func +=(lhs: inout _BigInt, rhs: _BigInt) {
+        defer { lhs._checkInvariants() }
+        if lhs.isNegative == rhs.isNegative {
+            lhs._unsignedAdd(rhs)
+        } else {
+            lhs -= -rhs
+        }
+    }
+
+    static func -=(lhs: inout _BigInt, rhs: _BigInt) {
+        defer { lhs._checkInvariants() }
+
+        // Subtracting something of the opposite sign just adds magnitude.
+        guard lhs.isNegative == rhs.isNegative else {
+            lhs._unsignedAdd(rhs)
+            return
+        }
+
+        // Comare `lhs` and `rhs` so we can use `_unsignedSubtract` to subtract
+        // the smaller magnitude from the larger magnitude.
+        switch lhs._compareMagnitude(to: rhs) {
+        case .equal:
+            lhs = 0
+        case .greaterThan:
+            lhs._unsignedSubtract(rhs)
+        case .lessThan:
+            // x - y == -y + x == -(y - x)
+            var result = rhs
+            result._unsignedSubtract(lhs)
+            result.isNegative = !lhs.isNegative
+            lhs = result
+        }
+    }
+
+    static func *=(lhs: inout _BigInt, rhs: _BigInt) {
+        // If either `lhs` or `rhs` is zero, the result is zero.
+        guard !lhs.isZero && !rhs.isZero else {
+            lhs = 0
+            return
+        }
+
+        var newData: [Word] = Array(repeating: 0,
+                                    count: lhs._data.count + rhs._data.count)
+        let (a, b) = lhs._data.count > rhs._data.count
+        ? (lhs._data, rhs._data)
+        : (rhs._data, lhs._data)
+        assert(a.count >= b.count)
+
+        var carry: Word = 0
+        for ai in 0..<a.count {
+            carry = 0
+            for bi in 0..<b.count {
+                // Each iteration needs to perform this operation:
+                //
+                //     newData[ai + bi] += (a[ai] * b[bi]) + carry
+                //
+                // However, `a[ai] * b[bi]` produces a double-width result, and both
+                // additions can overflow to a higher word. The following two lines
+                // capture the low word of the multiplication and additions in
+                // `newData[ai + bi]` and any addition overflow in `carry`.
+                let product = a[ai].multipliedFullWidth(by: b[bi])
+                (carry, newData[ai + bi]) = Word.addingFullWidth(
+                    newData[ai + bi], product.low, carry)
+
+                // Now we combine the high word of the multiplication with any addition
+                // overflow. It is safe to add `product.high` and `carry` here without
+                // checking for overflow, because if `product.high == .max - 1`, then
+                // `carry <= 1`. Otherwise, `carry <= 2`.
+                //
+                // Worst-case (aka 9 + 9*9 + 9):
+                //
+                //       newData         a[ai]        b[bi]         carry
+                //      0b11111111 + (0b11111111 * 0b11111111) + 0b11111111
+                //      0b11111111 + (0b11111110_____00000001) + 0b11111111
+                //                   (0b11111111_____00000000) + 0b11111111
+                //                   (0b11111111_____11111111)
+                //
+                // Second-worse case:
+                //
+                //      0b11111111 + (0b11111111 * 0b11111110) + 0b11111111
+                //      0b11111111 + (0b11111101_____00000010) + 0b11111111
+                //                   (0b11111110_____00000001) + 0b11111111
+                //                   (0b11111111_____00000000)
+                assert(!product.high.addingReportingOverflow(carry).overflow)
+                carry = product.high &+ carry
+            }
+
+            // Leftover `carry` is inserted in new highest word.
+            assert(newData[ai + b.count] == 0)
+            newData[ai + b.count] = carry
+        }
+
+        lhs._data = newData
+        lhs.isNegative = lhs.isNegative != rhs.isNegative
+        lhs._standardize()
+    }
+
+    /// Divides this instance by `rhs`, returning the remainder.
+    @discardableResult
+    mutating func _internalDivide(by rhs: _BigInt) -> _BigInt {
+        precondition(!rhs.isZero, "Divided by zero")
+        defer { _checkInvariants() }
+
+        // Handle quick cases that don't require division:
+        // If `abs(self) < abs(rhs)`, the result is zero, remainder = self
+        // If `abs(self) == abs(rhs)`, the result is 1 or -1, remainder = 0
+        switch _compareMagnitude(to: rhs) {
+        case .lessThan:
+            defer { self = 0 }
+            return self
+        case .equal:
+            self = isNegative != rhs.isNegative ? -1 : 1
+            return 0
+        default:
+            break
+        }
+
+        var tempSelf = self.magnitude
+        let n = tempSelf.bitWidth - rhs.magnitude.bitWidth
+        var quotient: _BigInt = 0
+        var tempRHS = rhs.magnitude << n
+        var tempQuotient: _BigInt = 1 << n
+
+        for _ in (0...n).reversed() {
+            if tempRHS._compareMagnitude(to: tempSelf) != .greaterThan {
+                tempSelf -= tempRHS
+                quotient += tempQuotient
+            }
+            tempRHS >>= 1
+            tempQuotient >>= 1
+        }
+
+        // `tempSelf` is the remainder - match sign of original `self`
+        tempSelf.isNegative = self.isNegative
+        tempSelf._standardize()
+
+        quotient.isNegative = isNegative != rhs.isNegative
+        self = quotient
+        _standardize()
+
+        return tempSelf
+    }
+
+    static func /=(lhs: inout _BigInt, rhs: _BigInt) {
+        lhs._internalDivide(by: rhs)
+    }
+
+    // FIXME: Remove once default implementations are provided:
+
+    static func +(_ lhs: _BigInt, _ rhs: _BigInt) -> _BigInt {
+        var lhs = lhs
+        lhs += rhs
+        return lhs
+    }
+
+    static func -(_ lhs: _BigInt, _ rhs: _BigInt) -> _BigInt {
+        var lhs = lhs
+        lhs -= rhs
+        return lhs
+    }
+
+    static func *(_ lhs: _BigInt, _ rhs: _BigInt) -> _BigInt {
+        var lhs = lhs
+        lhs *= rhs
+        return lhs
+    }
+
+    static func /(_ lhs: _BigInt, _ rhs: _BigInt) -> _BigInt {
+        var lhs = lhs
+        lhs /= rhs
+        return lhs
+    }
+
+    static func %(_ lhs: _BigInt, _ rhs: _BigInt) -> _BigInt {
+        var lhs = lhs
+        lhs %= rhs
+        return lhs
+    }
+
+    //===--- BinaryInteger --------------------------------------------------===//
+
+    /// Creates a new instance using the given data array in two's complement
+    /// representation.
+    init(_twosComplementData: [Word]) {
+        guard _twosComplementData.count > 0 else {
+            self = 0
+            return
+        }
+
+        // Is the highest bit set?
+        isNegative = _twosComplementData.last!.leadingZeroBitCount == 0
+        if isNegative {
+            _data = _twosComplementData.map(~)
+            self._unsignedAdd(1 as Word)
+        } else {
+            _data = _twosComplementData
+        }
+        _standardize()
+    }
+
+    /// Returns an array of the value's data using two's complement representation.
+    func _dataAsTwosComplement() -> [Word] {
+        // Special cases:
+        // * Nonnegative values are already in 2's complement
+        if !isNegative {
+            // Positive values need to have a leading zero bit
+            if _data.last?.leadingZeroBitCount == 0 {
+                return _data + [0]
+            } else {
+                return _data
+            }
+        }
+        // * -1 will get zeroed out below, easier to handle here
+        if _data.count == 1 && _data.first == 1 { return [~0] }
+
+        var x = self
+        x._unsignedSubtract(1 as Word)
+
+        if x._data.last!.leadingZeroBitCount == 0 {
+            // The highest bit is set to 1, which moves to 0 after negation.
+            // We need to add another word at the high end so the highest bit is 1.
+            return x._data.map(~) + [Word.max]
+        } else {
+            // The highest bit is set to 0, which moves to 1 after negation.
+            return x._data.map(~)
+        }
+    }
+
+    var words: [UInt] {
+        assert(UInt.bitWidth % Word.bitWidth == 0)
+        let twosComplementData = _dataAsTwosComplement()
+        var words: [UInt] = []
+        words.reserveCapacity((twosComplementData.count * Word.bitWidth
+                               + UInt.bitWidth - 1) / UInt.bitWidth)
+        var word: UInt = 0
+        var shift = 0
+        for w in twosComplementData {
+            word |= UInt(truncatingIfNeeded: w) << shift
+            shift += Word.bitWidth
+            if shift == UInt.bitWidth {
+                words.append(word)
+                word = 0
+                shift = 0
+            }
+        }
+        if shift != 0 {
+            if isNegative {
+                word |= ~((1 << shift) - 1)
+            }
+            words.append(word)
+        }
+        return words
+    }
+
+    /// The number of bits used for storage of this value. Always a multiple of
+    /// `Word.bitWidth`.
+    var bitWidth: Int {
+        if isZero {
+            return 0
+        } else {
+            let twosComplementData = _dataAsTwosComplement()
+
+            // If negative, it's okay to have 1s padded on high end
+            if isNegative {
+                return twosComplementData.count * Word.bitWidth
+            }
+
+            // If positive, need to make space for at least one zero on high end
+            return twosComplementData.count * Word.bitWidth
+            - twosComplementData.last!.leadingZeroBitCount + 1
+        }
+    }
+
+    /// The number of sequential zeros in the least-significant position of this
+    /// value's binary representation.
+    ///
+    /// The numbers 1 and zero have zero trailing zeros.
+    var trailingZeroBitCount: Int {
+        guard !isZero else {
+            return 0
+        }
+
+        let i = _data.firstIndex(where: { $0 != 0 })!
+        assert(_data[i] != 0)
+        return i * Word.bitWidth + _data[i].trailingZeroBitCount
+    }
+
+    static func %=(lhs: inout _BigInt, rhs: _BigInt) {
+        defer { lhs._checkInvariants() }
+        lhs = lhs._internalDivide(by: rhs)
+    }
+
+    func quotientAndRemainder(dividingBy rhs: _BigInt) ->
+    (_BigInt, _BigInt)
+    {
+        var x = self
+        let r = x._internalDivide(by: rhs)
+        return (x, r)
+    }
+
+    static func &=(lhs: inout _BigInt, rhs: _BigInt) {
+        var lhsTemp = lhs._dataAsTwosComplement()
+        let rhsTemp = rhs._dataAsTwosComplement()
+
+        // If `lhs` is longer than `rhs`, behavior depends on sign of `rhs`
+        // * If `rhs < 0`, length is extended with 1s
+        // * If `rhs >= 0`, length is extended with 0s, which crops `lhsTemp`
+        if lhsTemp.count > rhsTemp.count && !rhs.isNegative {
+            lhsTemp.removeLast(lhsTemp.count - rhsTemp.count)
+        }
+
+        // If `rhs` is longer than `lhs`, behavior depends on sign of `lhs`
+        // * If `lhs < 0`, length is extended with 1s, so `lhs` should get extra
+        //   bits from `rhs`
+        // * If `lhs >= 0`, length is extended with 0s
+        if lhsTemp.count < rhsTemp.count && lhs.isNegative {
+            lhsTemp.append(contentsOf: rhsTemp[lhsTemp.count..<rhsTemp.count])
+        }
+
+        // Perform bitwise & on words that both `lhs` and `rhs` have.
+        for i in 0..<Swift.min(lhsTemp.count, rhsTemp.count) {
+            lhsTemp[i] &= rhsTemp[i]
+        }
+
+        lhs = _BigInt(_twosComplementData: lhsTemp)
+    }
+
+    static func |=(lhs: inout _BigInt, rhs: _BigInt) {
+        var lhsTemp = lhs._dataAsTwosComplement()
+        let rhsTemp = rhs._dataAsTwosComplement()
+
+        // If `lhs` is longer than `rhs`, behavior depends on sign of `rhs`
+        // * If `rhs < 0`, length is extended with 1s, so those bits of `lhs`
+        //   should all be 1
+        // * If `rhs >= 0`, length is extended with 0s, which is a no-op
+        if lhsTemp.count > rhsTemp.count && rhs.isNegative {
+            lhsTemp.replaceSubrange(rhsTemp.count..<lhsTemp.count,
+                                    with: repeatElement(Word.max, count: lhsTemp.count - rhsTemp.count))
+        }
+
+        // If `rhs` is longer than `lhs`, behavior depends on sign of `lhs`
+        // * If `lhs < 0`, length is extended with 1s, so those bits of lhs
+        //   should all be 1
+        // * If `lhs >= 0`, length is extended with 0s, so those bits should be
+        //   copied from rhs
+        if lhsTemp.count < rhsTemp.count {
+            if lhs.isNegative {
+                lhsTemp.append(contentsOf:
+                                repeatElement(Word.max, count: rhsTemp.count - lhsTemp.count))
+            } else {
+                lhsTemp.append(contentsOf: rhsTemp[lhsTemp.count..<rhsTemp.count])
+            }
+        }
+
+        // Perform bitwise | on words that both `lhs` and `rhs` have.
+        for i in 0..<Swift.min(lhsTemp.count, rhsTemp.count) {
+            lhsTemp[i] |= rhsTemp[i]
+        }
+
+        lhs = _BigInt(_twosComplementData: lhsTemp)
+    }
+
+    static func ^=(lhs: inout _BigInt, rhs: _BigInt) {
+        var lhsTemp = lhs._dataAsTwosComplement()
+        let rhsTemp = rhs._dataAsTwosComplement()
+
+        // If `lhs` is longer than `rhs`, behavior depends on sign of `rhs`
+        // * If `rhs < 0`, length is extended with 1s, so those bits of `lhs`
+        //   should all be flipped
+        // * If `rhs >= 0`, length is extended with 0s, which is a no-op
+        if lhsTemp.count > rhsTemp.count && rhs.isNegative {
+            for i in rhsTemp.count..<lhsTemp.count {
+                lhsTemp[i] = ~lhsTemp[i]
+            }
+        }
+
+        // If `rhs` is longer than `lhs`, behavior depends on sign of `lhs`
+        // * If `lhs < 0`, length is extended with 1s, so those bits of `lhs`
+        //   should all be flipped copies of `rhs`
+        // * If `lhs >= 0`, length is extended with 0s, so those bits should
+        //   be copied from rhs
+        if lhsTemp.count < rhsTemp.count {
+            if lhs.isNegative {
+                lhsTemp += rhsTemp.suffix(from: lhsTemp.count).map(~)
+            } else {
+                lhsTemp.append(contentsOf: rhsTemp[lhsTemp.count..<rhsTemp.count])
+            }
+        }
+
+        // Perform bitwise ^ on words that both `lhs` and `rhs` have.
+        for i in 0..<Swift.min(lhsTemp.count, rhsTemp.count) {
+            lhsTemp[i] ^= rhsTemp[i]
+        }
+
+        lhs = _BigInt(_twosComplementData: lhsTemp)
+    }
+
+    static prefix func ~(x: _BigInt) -> _BigInt {
+        return -x - 1
+    }
+
+    //===--- SignedNumeric --------------------------------------------------===//
+
+    static prefix func -(x: inout _BigInt) {
+        defer { x._checkInvariants() }
+        guard x._data.count > 0 else { return }
+        x.isNegative = !x.isNegative
+    }
+
+    //===--- Strideable -----------------------------------------------------===//
+
+    func distance(to other: _BigInt) -> _BigInt {
+        return other - self
+    }
+
+    func advanced(by n: _BigInt) -> _BigInt {
+        return self + n
+    }
+
+    //===--- Other arithmetic -----------------------------------------------===//
+
+    /// Returns the greatest common divisor for this value and `other`.
+    func greatestCommonDivisor(with other: _BigInt) -> _BigInt {
+        // Quick return if either is zero
+        if other.isZero {
+            return magnitude
+        }
+        if isZero {
+            return other.magnitude
+        }
+
+        var (x, y) = (self.magnitude, other.magnitude)
+        let (xLSB, yLSB) = (x.trailingZeroBitCount, y.trailingZeroBitCount)
+
+        // Remove any common factor of two
+        let commonPower = Swift.min(xLSB, yLSB)
+        x >>= commonPower
+        y >>= commonPower
+
+        // Remove any remaining factor of two
+        if xLSB != commonPower {
+            x >>= xLSB - commonPower
+        }
+        if yLSB != commonPower {
+            y >>= yLSB - commonPower
+        }
+
+        while !x.isZero {
+            // Swap values to ensure that `x >= y`.
+            if x._compareMagnitude(to: y) == .lessThan {
+                swap(&x, &y)
+            }
+
+            // Subtract smaller and remove any factors of two
+            x._unsignedSubtract(y)
+            x >>= x.trailingZeroBitCount
+        }
+
+        // Add original common factor of two back into result
+        y <<= commonPower
+        return y
+    }
+
+    /// Returns the lowest common multiple for this value and `other`.
+    func lowestCommonMultiple(with other: _BigInt) -> _BigInt {
+        let gcd = greatestCommonDivisor(with: other)
+        if _compareMagnitude(to: other) == .lessThan {
+            return ((self / gcd) * other).magnitude
+        } else {
+            return ((other / gcd) * self).magnitude
+        }
+    }
+
+    //===--- String methods ------------------------------------------------===//
+
+    /// Creates a new instance from the given string.
+    ///
+    /// - Parameters:
+    ///   - source: The string to parse for the new instance's value. If a
+    ///     character in `source` is not in the range `0...9` or `a...z`, case
+    ///     insensitive, or is not less than `radix`, the result is `nil`.
+    ///   - radix: The radix to use when parsing `source`. `radix` must be in the
+    ///     range `2...36`. The default is `10`.
+    init?(_ source: String, radix: Int = 10) {
+        assert(2...36 ~= radix, "radix must be in range 2...36")
+        let radix = Word(radix)
+
+        func valueForCodeUnit(_ unit: Unicode.UTF16.CodeUnit) -> Word? {
+            switch unit {
+                // "0"..."9"
+            case 48...57: return Word(unit - 48)
+                // "a"..."z"
+            case 97...122: return Word(unit - 87)
+                // "A"..."Z"
+            case 65...90: return Word(unit - 55)
+                // invalid character
+            default: return nil
+            }
+        }
+
+        var source = source
+
+        // Check for a single prefixing hyphen
+        let negative = source.hasPrefix("-")
+        if negative {
+            source = String(source.dropFirst())
+        }
+
+        // Loop through characters, multiplying
+        for v in source.utf16.map(valueForCodeUnit) {
+            // Character must be valid and less than radix
+            guard let v = v else { return nil }
+            guard v < radix else { return nil }
+
+            self.multiply(by: radix)
+            self.add(v)
+        }
+
+        self.isNegative = negative
+    }
+
+    /// Returns a string representation of this instance.
+    ///
+    /// - Parameters:
+    ///   - radix: The radix to use when converting this instance to a string.
+    ///     The value passed as `radix` must be in the range `2...36`. The
+    ///     default is `10`.
+    ///   - lowercase: Whether to use lowercase letters to represent digits
+    ///     greater than 10. The default is `true`.
+    func toString(radix: Int = 10, lowercase: Bool = true) -> String {
+        assert(2...36 ~= radix, "radix must be in range 2...36")
+
+        let digitsStart = ("0" as Unicode.Scalar).value
+        let lettersStart = ((lowercase ? "a" : "A") as Unicode.Scalar).value - 10
+        func toLetter(_ x: UInt32) -> Unicode.Scalar {
+            return x < 10
+            ? Unicode.Scalar(digitsStart + x)!
+            : Unicode.Scalar(lettersStart + x)!
+        }
+
+        let radix = _BigInt(radix)
+        var result: [Unicode.Scalar] = []
+
+        var x = self.magnitude
+        while !x.isZero {
+            let remainder: _BigInt
+            (x, remainder) = x.quotientAndRemainder(dividingBy: radix)
+            result.append(toLetter(UInt32(remainder)))
+        }
+
+        let sign = isNegative ? "-" : ""
+        let rest = result.count == 0
+        ? "0"
+        : String(String.UnicodeScalarView(result.reversed()))
+        return sign + rest
+    }
+
+    var description: String {
+        return decimalString
+    }
+
+    var debugDescription: String {
+        return "_BigInt(\(hexString), words: \(_data.count))"
+    }
+
+    /// A string representation of this instance's value in base 2.
+    var binaryString: String {
+        return toString(radix: 2)
+    }
+
+    /// A string representation of this instance's value in base 10.
+    var decimalString: String {
+        return toString(radix: 10)
+    }
+
+    /// A string representation of this instance's value in base 16.
+    var hexString: String {
+        return toString(radix: 16, lowercase: false)
+    }
+
+    /// A string representation of this instance's value in base 36.
+    var compactString: String {
+        return toString(radix: 36, lowercase: false)
+    }
+
+    //===--- Comparable -----------------------------------------------------===//
+
+    enum _ComparisonResult {
+        case lessThan, equal, greaterThan
+    }
+
+    /// Returns whether this instance is less than, greather than, or equal to
+    /// the given value.
+    func _compare(to rhs: _BigInt) -> _ComparisonResult {
+        // Negative values are less than positive values
+        guard isNegative == rhs.isNegative else {
+            return isNegative ? .lessThan : .greaterThan
+        }
+
+        switch _compareMagnitude(to: rhs) {
+        case .equal:
+            return .equal
+        case .lessThan:
+            return isNegative ? .greaterThan : .lessThan
+        case .greaterThan:
+            return isNegative ? .lessThan : .greaterThan
+        }
+    }
+
+    /// Returns whether the magnitude of this instance is less than, greather
+    /// than, or equal to the magnitude of the given value.
+    func _compareMagnitude(to rhs: _BigInt) -> _ComparisonResult {
+        guard _data.count == rhs._data.count else {
+            return _data.count < rhs._data.count ? .lessThan : .greaterThan
+        }
+
+        // Equal number of words: compare from most significant word
+        for i in (0..<_data.count).reversed() {
+            if _data[i] < rhs._data[i] { return .lessThan }
+            if _data[i] > rhs._data[i] { return .greaterThan }
+        }
+        return .equal
+    }
+
+    static func ==(lhs: _BigInt, rhs: _BigInt) -> Bool {
+        return lhs._compare(to: rhs) == .equal
+    }
+
+    static func < (lhs: _BigInt, rhs: _BigInt) -> Bool {
+        return lhs._compare(to: rhs) == .lessThan
+    }
+
+    //===--- Hashable -------------------------------------------------------===//
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(isNegative)
+        hasher.combine(_data)
+    }
+
+    //===--- Bit shifting operators -----------------------------------------===//
+
+    static func _shiftLeft(_ data: inout [Word], byWords words: Int) {
+        guard words > 0 else { return }
+        data.insert(contentsOf: repeatElement(0, count: words), at: 0)
+    }
+
+    static func _shiftRight(_ data: inout [Word], byWords words: Int) {
+        guard words > 0 else { return }
+        data.removeFirst(Swift.min(data.count, words))
+    }
+
+    static func <<= <RHS : BinaryInteger>(lhs: inout _BigInt, rhs: RHS) {
+        defer { lhs._checkInvariants() }
+        guard rhs != 0 else { return }
+        guard rhs > 0 else {
+            lhs >>= 0 - rhs
+            return
+        }
+
+        let wordWidth = RHS(Word.bitWidth)
+
+        // We can add `rhs / bits` extra words full of zero at the low end.
+        let extraWords = Int(rhs / wordWidth)
+        lhs._data.reserveCapacity(lhs._data.count + extraWords + 1)
+        _BigInt._shiftLeft(&lhs._data, byWords: extraWords)
+
+        // Each existing word will need to be shifted left by `rhs % bits`.
+        // For each pair of words, we'll use the high `offset` bits of the
+        // lower word and the low `Word.bitWidth - offset` bits of the higher
+        // word.
+        let highOffset = Int(rhs % wordWidth)
+        let lowOffset = Word.bitWidth - highOffset
+
+        // If there's no offset, we're finished, as `rhs` was a multiple of
+        // `Word.bitWidth`.
+        guard highOffset != 0 else { return }
+
+        // Add new word at the end, then shift everything left by `offset` bits.
+        lhs._data.append(0)
+        for i in ((extraWords + 1)..<lhs._data.count).reversed() {
+            lhs._data[i] = lhs._data[i] << highOffset
+            | lhs._data[i - 1] >> lowOffset
+        }
+
+        // Finally, shift the lowest word.
+        lhs._data[extraWords] = lhs._data[extraWords] << highOffset
+        lhs._standardize()
+    }
+
+    static func >>= <RHS : BinaryInteger>(lhs: inout _BigInt, rhs: RHS) {
+        defer { lhs._checkInvariants() }
+        guard rhs != 0 else { return }
+        guard rhs > 0 else {
+            lhs <<= 0 - rhs
+            return
+        }
+
+        var tempData = lhs._dataAsTwosComplement()
+
+        let wordWidth = RHS(Word.bitWidth)
+        // We can remove `rhs / bits` full words at the low end.
+        // If that removes the entirety of `_data`, we're done.
+        let wordsToRemove = Int(rhs / wordWidth)
+        _BigInt._shiftRight(&tempData, byWords: wordsToRemove)
+        guard tempData.count != 0 else {
+            lhs = lhs.isNegative ? -1 : 0
+            return
+        }
+
+        // Each existing word will need to be shifted right by `rhs % bits`.
+        // For each pair of words, we'll use the low `offset` bits of the
+        // higher word and the high `_BigInt.Word.bitWidth - offset` bits of
+        // the lower word.
+        let lowOffset = Int(rhs % wordWidth)
+        let highOffset = Word.bitWidth - lowOffset
+
+        // If there's no offset, we're finished, as `rhs` was a multiple of
+        // `Word.bitWidth`.
+        guard lowOffset != 0 else {
+            lhs = _BigInt(_twosComplementData: tempData)
+            return
+        }
+
+        // Shift everything right by `offset` bits.
+        for i in 0..<(tempData.count - 1) {
+            tempData[i] = tempData[i] >> lowOffset |
+            tempData[i + 1] << highOffset
+        }
+
+        // Finally, shift the highest word and standardize the result.
+        tempData[tempData.count - 1] >>= lowOffset
+        lhs = _BigInt(_twosComplementData: tempData)
+    }
+}
+
+//===--- Bit --------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+/// A one-bit fixed width integer.
+struct Bit : FixedWidthInteger, UnsignedInteger {
+    typealias Magnitude = Bit
+
+    var value: UInt8 = 0
+
+    // Initializers
+
+    init(integerLiteral value: Int) {
+        self = Bit(value)
+    }
+
+    init(bigEndian value: Bit) {
+        self = value
+    }
+
+    init(littleEndian value: Bit) {
+        self = value
+    }
+
+    init?<T: BinaryFloatingPoint>(exactly source: T) {
+        switch source {
+        case T(0): value = 0
+        case T(1): value = 1
+        default:
+            return nil
+        }
+    }
+
+    init<T: BinaryFloatingPoint>(_ source: T) {
+        self = Bit(exactly: source.rounded(.down))!
+    }
+
+    init<T: BinaryInteger>(_ source: T) {
+        switch source {
+        case 0: value = 0
+        case 1: value = 1
+        default:
+            fatalError("Can't represent \(source) as a Bit")
+        }
+    }
+
+    init<T: BinaryInteger>(truncatingIfNeeded source: T) {
+        value = UInt8(source & 1)
+    }
+
+    init(_truncatingBits bits: UInt) {
+        value = UInt8(bits & 1)
+    }
+
+    init<T: BinaryInteger>(clamping source: T)  {
+        value = source >= 1 ? 1 : 0
+    }
+
+    // FixedWidthInteger, BinaryInteger
+
+    static var bitWidth: Int {
+        return 1
+    }
+
+    var bitWidth: Int {
+        return 1
+    }
+
+    var trailingZeroBitCount: Int {
+        return Int(~value & 1)
+    }
+
+    static var max: Bit {
+        return 1
+    }
+
+    static var min: Bit {
+        return 0
+    }
+
+    static var isSigned: Bool {
+        return false
+    }
+
+    var nonzeroBitCount: Int {
+        return value.nonzeroBitCount
+    }
+
+    var leadingZeroBitCount: Int {
+        return Int(~value & 1)
+    }
+
+    var bigEndian: Bit {
+        return self
+    }
+
+    var littleEndian: Bit {
+        return self
+    }
+
+    var byteSwapped: Bit {
+        return self
+    }
+
+    var words: UInt.Words {
+        return UInt(value).words
+    }
+
+    // Hashable, CustomStringConvertible
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
+
+    var description: String {
+        return "\(value)"
+    }
+
+    // Arithmetic Operations / Operators
+
+    func _checkOverflow(_ v: UInt8) -> Bool {
+        let mask: UInt8 = ~0 << 1
+        return v & mask != 0
+    }
+
+    func addingReportingOverflow(_ rhs: Bit) ->
+    (partialValue: Bit, overflow: Bool) {
+        let result = value &+ rhs.value
+        return (Bit(result & 1), _checkOverflow(result))
+    }
+
+    func subtractingReportingOverflow(_ rhs: Bit) ->
+    (partialValue: Bit, overflow: Bool) {
+        let result = value &- rhs.value
+        return (Bit(result & 1), _checkOverflow(result))
+    }
+
+    func multipliedReportingOverflow(by rhs: Bit) ->
+    (partialValue: Bit, overflow: Bool) {
+        let result = value &* rhs.value
+        return (Bit(result), false)
+    }
+
+    func dividedReportingOverflow(by rhs: Bit) ->
+    (partialValue: Bit, overflow: Bool) {
+        return (self, rhs != 0)
+    }
+
+    func remainderReportingOverflow(dividingBy rhs: Bit) ->
+    (partialValue: Bit, overflow: Bool) {
+        fatalError()
+    }
+
+    static func +=(lhs: inout Bit, rhs: Bit) {
+        let result = lhs.addingReportingOverflow(rhs)
+        assert(!result.overflow, "Addition overflow")
+        lhs = result.partialValue
+    }
+
+    static func -=(lhs: inout Bit, rhs: Bit) {
+        let result = lhs.subtractingReportingOverflow(rhs)
+        assert(!result.overflow, "Subtraction overflow")
+        lhs = result.partialValue
+    }
+
+    static func *=(lhs: inout Bit, rhs: Bit) {
+        let result = lhs.multipliedReportingOverflow(by: rhs)
+        assert(!result.overflow, "Multiplication overflow")
+        lhs = result.partialValue
+    }
+
+    static func /=(lhs: inout Bit, rhs: Bit) {
+        let result = lhs.dividedReportingOverflow(by: rhs)
+        assert(!result.overflow, "Division overflow")
+        lhs = result.partialValue
+    }
+
+    static func %=(lhs: inout Bit, rhs: Bit) {
+        assert(rhs != 0, "Modulo sum overflow")
+        lhs.value = 0 // No remainders with bit division!
+    }
+
+    func multipliedFullWidth(by other: Bit) -> (high: Bit, low: Bit) {
+        return (0, self * other)
+    }
+
+    func dividingFullWidth(_ dividend: (high: Bit, low: Bit)) ->
+    (quotient: Bit, remainder: Bit) {
+        assert(self != 0, "Division overflow")
+        assert(dividend.high == 0, "Quotient overflow")
+        return (dividend.low, 0)
+    }
+
+    // FIXME: Remove once default implementations are provided:
+
+    static func +(_ lhs: Bit, _ rhs: Bit) -> Bit {
+        var lhs = lhs
+        lhs += rhs
+        return lhs
+    }
+
+    static func -(_ lhs: Bit, _ rhs: Bit) -> Bit {
+        var lhs = lhs
+        lhs -= rhs
+        return lhs
+    }
+
+    static func *(_ lhs: Bit, _ rhs: Bit) -> Bit {
+        var lhs = lhs
+        lhs *= rhs
+        return lhs
+    }
+
+    static func /(_ lhs: Bit, _ rhs: Bit) -> Bit {
+        var lhs = lhs
+        lhs /= rhs
+        return lhs
+    }
+
+    static func %(_ lhs: Bit, _ rhs: Bit) -> Bit {
+        var lhs = lhs
+        lhs %= rhs
+        return lhs
+    }
+
+    // Bitwise operators
+
+    static prefix func ~(x: Bit) -> Bit {
+        return Bit(~x.value & 1)
+    }
+
+    // Why doesn't the type checker complain about these being missing?
+    static func &=(lhs: inout Bit, rhs: Bit) {
+        lhs.value &= rhs.value
+    }
+
+    static func |=(lhs: inout Bit, rhs: Bit) {
+        lhs.value |= rhs.value
+    }
+
+    static func ^=(lhs: inout Bit, rhs: Bit) {
+        lhs.value ^= rhs.value
+    }
+
+    static func ==(lhs: Bit, rhs: Bit) -> Bool {
+        return lhs.value == rhs.value
+    }
+
+    static func <(lhs: Bit, rhs: Bit) -> Bool {
+        return lhs.value < rhs.value
+    }
+
+    static func <<(lhs: Bit, rhs: Bit) -> Bit {
+        return rhs == 0 ? lhs : 0
+    }
+
+    static func >>(lhs: Bit, rhs: Bit) -> Bit {
+        return rhs == 0 ? lhs : 0
+    }
+
+    static func <<=(lhs: inout Bit, rhs: Bit) {
+        if rhs != 0 {
+            lhs = 0
+        }
+    }
+
+    static func >>=(lhs: inout Bit, rhs: Bit) {
+        if rhs != 0 {
+            lhs = 0
+        }
+    }
+}

--- a/TangemSdk/TangemSdk/Crypto/BLS/BigInt.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/BigInt.swift
@@ -1000,7 +1000,14 @@ where Word.Magnitude == Word
 
     /// A string representation of this instance's value in base 16.
     var hexString: String {
-        return toString(radix: 16, lowercase: false)
+        let string = toString(radix: 16, lowercase: false)
+
+        let isEven = string.count % 2 == 0
+        if isEven {
+            return string
+        } else {
+            return "0" + string
+        }
     }
 
     /// A string representation of this instance's value in base 36.

--- a/TangemSdk/TangemSdk/Crypto/BLS/HKDFUtil.swift
+++ b/TangemSdk/TangemSdk/Crypto/BLS/HKDFUtil.swift
@@ -1,0 +1,52 @@
+//
+//  HKDFUtil.swift
+//  TangemSdk
+//
+//  Created by Alexander Osokin on 25.05.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+import CommonCrypto
+
+/// We can't use CryptoKit's HKDF because of iOS14
+/// https://www.rfc-editor.org/rfc/rfc5869
+@available(iOS 13.0, *)
+enum HKDFUtil<H: HashFunction> {
+    
+    /// HKDF-Extract(salt, IKM) -> PRK
+    /// - Parameters:
+    ///   - inputKeyMaterial: input keying material
+    ///   - salt: optional salt value (a non-secret random value); if not provided, it is set to a string of HashLen zeros.
+    /// - Returns: a pseudorandom key (of HashLen octets)
+    static func extract(inputKeyMaterial: Data, salt: Data? = nil) -> Data {
+        let prk = HMAC<H>.authenticationCode(for: inputKeyMaterial, using: SymmetricKey(data: salt ?? Data()))
+        return Data(prk)
+    }
+    
+    /// HKDF-Expand(PRK, info, L) -> OKM
+    /// - Parameters:
+    ///   - pseudoRandomKey: a pseudorandom key of at least HashLen octets (usually, the output from the extract step)
+    ///   - info: optional context and application specific information (can be a zero-length octet string)
+    ///   - outputByteCount: length of output keying material in octets (<=255*HashLen)
+    /// - Returns: output keying material (of L octets)
+    static func expand(pseudoRandomKey: Data, info: Data? = nil, outputByteCount: Int) -> Data {
+        let hashSize = H.Digest.byteCount
+        let iterations = Int(ceil(Double(outputByteCount) / Double(hashSize)))
+        
+        var result = Data()
+        result.reserveCapacity(iterations*hashSize)
+        
+        for iteration in 1...iterations {
+            var hmac = HMAC<H>(key: SymmetricKey(data: pseudoRandomKey))
+            hmac.update(data: result)
+            hmac.update(data: info ?? Data())
+            hmac.update(data: iteration.byte)
+            let code = hmac.finalize()
+            result.append(contentsOf: code)
+        }
+        
+        return result.prefix(outputByteCount)
+    }
+}

--- a/TangemSdk/TangemSdkTests/BLSTests.swift
+++ b/TangemSdk/TangemSdkTests/BLSTests.swift
@@ -1,0 +1,38 @@
+//
+//  BLSTests.swift
+//  TangemSdkTests
+//
+//  Created by Alexander Osokin on 25.05.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import TangemSdk
+
+@available(iOS 13.0, *)
+class BLSTests: XCTestCase {
+    func testCase0() throws {
+        let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04"))
+
+        XCTAssertEqual(key.hexString, "6083874454709270928345386274498605044986640685124978867557563392430687146096".data(using: .utf8)!.hexString)
+    }
+
+    func testCase1() throws {
+        let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0x3141592653589793238462643383279502884197169399375105820974944592"))
+
+        XCTAssertEqual(key.hexString, "29757020647961307431480504535336562678282505419141012933316116377660817309383".data(using: .utf8)!.hexString)
+    }
+
+    func testCase2() throws {
+        let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0x0099FF991111002299DD7744EE3355BBDD8844115566CC55663355668888CC00"))
+
+        XCTAssertEqual(key.hexString, "27580842291869792442942448775674722299803720648445448686099262467207037398656".data(using: .utf8)!.hexString)
+    }
+
+    func testCase3() throws {
+        let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"))
+
+        XCTAssertEqual(key.hexString, "19022158461524446591288038168518313374041767046816487870552872741050760015818".data(using: .utf8)!.hexString)
+    }
+}

--- a/TangemSdk/TangemSdkTests/BLSTests.swift
+++ b/TangemSdk/TangemSdkTests/BLSTests.swift
@@ -15,24 +15,28 @@ class BLSTests: XCTestCase {
     func testCase0() throws {
         let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04"))
 
-        XCTAssertEqual(key.hexString, "6083874454709270928345386274498605044986640685124978867557563392430687146096".data(using: .utf8)!.hexString)
+        // 6083874454709270928345386274498605044986640685124978867557563392430687146096 in decimal representation
+        XCTAssertEqual(key.hexString.lowercased(), "0d7359d57963ab8fbbde1852dcf553fedbc31f464d80ee7d40ae683122b45070")
     }
 
     func testCase1() throws {
         let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0x3141592653589793238462643383279502884197169399375105820974944592"))
 
-        XCTAssertEqual(key.hexString, "29757020647961307431480504535336562678282505419141012933316116377660817309383".data(using: .utf8)!.hexString)
+        // 29757020647961307431480504535336562678282505419141012933316116377660817309383 in decimal representation
+        XCTAssertEqual(key.hexString.lowercased(), "41c9e07822b092a93fd6797396338c3ada4170cc81829fdfce6b5d34bd5e7ec7")
     }
 
     func testCase2() throws {
         let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0x0099FF991111002299DD7744EE3355BBDD8844115566CC55663355668888CC00"))
 
-        XCTAssertEqual(key.hexString, "27580842291869792442942448775674722299803720648445448686099262467207037398656".data(using: .utf8)!.hexString)
+        // 27580842291869792442942448775674722299803720648445448686099262467207037398656 in decimal representation
+        XCTAssertEqual(key.hexString.lowercased(), "3cfa341ab3910a7d00d933d8f7c4fe87c91798a0397421d6b19fd5b815132e80")
     }
 
     func testCase3() throws {
         let key = try BLSUtils().generateKey(inputKeyMaterial: Data(hexString: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"))
 
-        XCTAssertEqual(key.hexString, "19022158461524446591288038168518313374041767046816487870552872741050760015818".data(using: .utf8)!.hexString)
+        // 19022158461524446591288038168518313374041767046816487870552872741050760015818 in decimal representation
+        XCTAssertEqual(key.hexString.lowercased(), "2a0e28ffa5fbbe2f8e7aad4ed94f745d6bf755c51182e119bb1694fe61d3afca")
     }
 }

--- a/TangemSdk/TangemSdkTests/HKDFTests.swift
+++ b/TangemSdk/TangemSdkTests/HKDFTests.swift
@@ -1,0 +1,50 @@
+//
+//  HKDFTests.swift
+//  TangemSdkTests
+//
+//  Created by Alexander Osokin on 26.05.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import CryptoKit
+@testable import TangemSdk
+
+@available(iOS 13.0, *)
+/// https://www.rfc-editor.org/rfc/rfc5869 without SHA1
+class HKDFTests: XCTestCase {
+    func testCase1() {
+        let ikm = Data(hexString: "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        let salt = Data(hexString: "0x000102030405060708090a0b0c")
+        let info = Data(hexString: "0xf0f1f2f3f4f5f6f7f8f9")
+        let l = 42
+
+        let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: ikm, salt: salt)
+        XCTAssertEqual(prk, Data(hexString: "0x077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"))
+        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: l)
+        XCTAssertEqual(okm, Data(hexString: "0x3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"))
+    }
+
+    func testCase2() {
+        let ikm = Data(hexString: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f")
+        let salt = Data(hexString: "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf")
+        let info = Data(hexString: "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff")
+        let l = 82
+
+        let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: ikm, salt: salt)
+        XCTAssertEqual(prk, Data(hexString: "0x06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"))
+        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: l)
+        XCTAssertEqual(okm.hexString, Data(hexString: "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87").hexString)
+    }
+
+    func testCase3() {
+        let ikm = Data(hexString: "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        let l = 42
+
+        let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: ikm)
+        XCTAssertEqual(prk, Data(hexString: "0x19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"))
+        let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, outputByteCount: l)
+        XCTAssertEqual(okm, Data(hexString: "0x8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"))
+    }
+}

--- a/TangemSdk/TangemSdkTests/HKDFTests.swift
+++ b/TangemSdk/TangemSdkTests/HKDFTests.swift
@@ -26,16 +26,18 @@ class HKDFTests: XCTestCase {
         XCTAssertEqual(okm, Data(hexString: "0x3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"))
     }
 
+
     func testCase2() {
-        let ikm = Data(hexString: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f")
-        let salt = Data(hexString: "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf")
-        let info = Data(hexString: "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff")
+        let ikm = Data(hexString: "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f")
+        let salt = Data(hexString: "0x606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf")
+        let info = Data(hexString: "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff")
         let l = 82
 
         let prk = HKDFUtil<SHA256>.extract(inputKeyMaterial: ikm, salt: salt)
         XCTAssertEqual(prk, Data(hexString: "0x06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"))
         let okm = HKDFUtil<SHA256>.expand(pseudoRandomKey: prk, info: info, outputByteCount: l)
-        XCTAssertEqual(okm.hexString, Data(hexString: "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87").hexString)
+        XCTAssertEqual(okm.hexString, Data(hexString: "0xb11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87").hexString)
+        
     }
 
     func testCase3() {


### PR DESCRIPTION
- Реализовано создание секретного ключа из сида для BLS. Пока в двух вариантах - совместимо с чиа и с актуальным стандартном. По умолчанию совместимость со стандартом, дальше разберемся какой вариант использовать. 

Пришлось реализовать HKDF, потому что в криптокит ее завезли только с иос14. Еще понадобился BigInt, затащил прототип из сортов Свифта, не хочется большие зависимости тянуть. Пришлось доработать стерилизацию в хекс, потому что возвращался строка с нечетным числом символов. (см var hexString: String)


- В CreateWallet теперь пречек на созданный кошелек теперь опциоанльный, потому что для BLS релизовать трудозатратно. Карта все равно не даст записать.

- dataRepresentation не работает для, например SymmetricKey, сделал private, чтобы не выстрелить в ногу.

- добавил тесты для HKDF и генерации гюча из тест векторов соответствующих стандартов
