### PR TITLE
Fix BackupStatus.isActive checks

### DIFF
--- a/TangemSdk/TangemSdk/Common/Card/Card.swift
+++ b/TangemSdk/TangemSdk/Common/Card/Card.swift
@@ -95,6 +95,24 @@ public extension Card {
         
         public var isActive: Bool {
             switch self {
+            case .active:
+                return true
+            default:
+                return false
+            }
+        }
+
+        public var canBackup: Bool {
+            switch self {
+            case .noBackup:
+                return true
+            default:
+                return false
+            }
+        }
+
+        public var canReset: Bool {
+            switch self {
             case .active, .cardLinked:
                 return true
             default:

--- a/TangemSdk/TangemSdk/Operations/Backup/ResetBackupCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/ResetBackupCommand.swift
@@ -34,9 +34,9 @@ public final class ResetBackupCommand: Command {
         }
         
         guard let backupStatus = card.backupStatus,
-              backupStatus.isActive else {
-                  return TangemSdkError.noActiveBackup
-              }
+              backupStatus.canReset else {
+            return TangemSdkError.noActiveBackup
+        }
         
         guard !card.wallets.contains(where: { $0.hasBackup } ) else {
             return TangemSdkError.resetBackupFailedHasBackedUpWallets

--- a/TangemSdk/TangemSdk/Operations/Backup/StartBackupCardLinkingCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/StartBackupCardLinkingCommand.swift
@@ -32,8 +32,8 @@ final class StartBackupCardLinkingCommand: Command {
             return .backupNotAllowed
         }
 
-        if let backupStatus = card.backupStatus, backupStatus.isActive {
-            return .backupFailedAlreadyCreated
+        guard let backupStatus = card.backupStatus, backupStatus.canBackup else {
+            return TangemSdkError.backupFailedAlreadyCreated
         }
         
         if !card.wallets.isEmpty {

--- a/TangemSdk/TangemSdk/Operations/Backup/StartPrimaryCardLinkingCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/StartPrimaryCardLinkingCommand.swift
@@ -27,8 +27,8 @@ public final class StartPrimaryCardLinkingCommand: Command {
             return .backupNotAllowed
         }
 
-        if let backupStatus = card.backupStatus, backupStatus.isActive {
-            return .backupFailedAlreadyCreated
+        guard let backupStatus = card.backupStatus, backupStatus.canBackup else {
+            return TangemSdkError.backupFailedAlreadyCreated
         }
         
         if card.wallets.isEmpty {


### PR DESCRIPTION
Неправильно интерпретировался промежуточный стейт isLinked. 

-isActive - только если бэкап действительно завершен (состояние active). В таком случае становится доступен сброс пароля и дополнительная аттестация.

- Линковка карт(бэкап) доступна только если карты в noBackup

- Сброс бэкапа доступен и для linked и для active состояний