### PR TITLE
IOS-3767 Refactor chunking

### DIFF
--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -275,6 +275,7 @@ class SignCommand: Command {
 @available(iOS 13.0, *)
 private extension SignCommand {
     enum Constants {
+        /// The max answer is 1152 bytes (unencrypted) and 1120 (encrypted). The worst case is 8 hashes * 64 bytes for ed + 512 bytes of signatures + cardId, SignedHashes + TLV + SW is ok.
         static let packageSize = 512
         static let maxChunkSize = 10
         static let maxChunkSizePoorNfcQualityDevice = 2

--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -33,7 +33,18 @@ class SignCommand: Command {
     }
     
     private lazy var chunkSize: Int = {
-        return NFCUtils.isPoorNfcQualityDevice ? 2 : 10
+        /// These devices are not able to sign long hashes.
+        if NFCUtils.isPoorNfcQualityDevice {
+            return Constants.maxChunkSizePoorNfcQualityDevice
+        }
+
+        if let hashSize = hashes.first?.count, hashSize > 0 {
+            let estimatedChunkSize = Int((Double(Constants.packageSize) / Double(hashSize)).rounded(.down))
+            let chunkSize = min(estimatedChunkSize, Constants.maxChunkSize)
+            return chunkSize
+        }
+
+        return Constants.maxChunkSize
     }()
     
     private lazy var numberOfChunks: Int = {
@@ -257,5 +268,15 @@ class SignCommand: Command {
               }
         
         return environment.terminalKeys
+    }
+}
+
+
+@available(iOS 13.0, *)
+private extension SignCommand {
+    enum Constants {
+        static let packageSize = 512
+        static let maxChunkSize = 10
+        static let maxChunkSizePoorNfcQualityDevice = 2
     }
 }

--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -277,7 +277,11 @@ private extension SignCommand {
     enum Constants {
         /// The max answer is 1152 bytes (unencrypted) and 1120 (encrypted). The worst case is 8 hashes * 64 bytes for ed + 512 bytes of signatures + cardId, SignedHashes + TLV + SW is ok.
         static let packageSize = 512
+
+        /// Card limitation
         static let maxChunkSize = 10
+
+        /// Empirical value
         static let maxChunkSizePoorNfcQualityDevice = 2
     }
 }

--- a/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Sign/SignCommand.swift
@@ -39,8 +39,8 @@ class SignCommand: Command {
         }
 
         if let hashSize = hashes.first?.count, hashSize > 0 {
-            let estimatedChunkSize = Int((Double(Constants.packageSize) / Double(hashSize)).rounded(.down))
-            let chunkSize = min(estimatedChunkSize, Constants.maxChunkSize)
+            let estimatedChunkSize = Constants.packageSize / hashSize
+            let chunkSize = max(1, min(estimatedChunkSize, Constants.maxChunkSize))
             return chunkSize
         }
 


### PR DESCRIPTION
Теперь чанк рассчитывается на основе размера пакета.
Примеры 

192 байта - 2 хэша за раз
96 байт - 5 за раз
64 байта - 8 за раз
32 байте - 10 за раз (макс значение)