### PR TITLE
IOS-5072 Update bad NFC device list

### DIFF
--- a/TangemSdk/TangemSdk/Common/NFC/NFCUtils.swift
+++ b/TangemSdk/TangemSdk/Common/NFC/NFCUtils.swift
@@ -14,28 +14,57 @@ public class NFCUtils {
     /// Check if the current device doesn't support the desired NFC operations
     public static var isNFCAvailable: Bool {
         if NSClassFromString("NFCNDEFReaderSession") == nil { return false }
-        
+
         if #available(iOS 13.0, *) {
             return NFCNDEFReaderSession.readingAvailable
         } else {
-           return false
+            return false
         }
     }
-    
+
     public static var isPoorNfcQualityDevice: Bool {
         return poorNFCQualityDevices.contains(identifier)
     }
 
     static var isBrokenRestartPollingDevice: Bool {
-        return brokenRestartPollingDevices.contains(identifier)
+        return !correctRestartPollingDevices.contains(identifier)
     }
 
     // iPhone 7 family
     private static let poorNFCQualityDevices = ["iPhone9,1", "iPhone9,3", "iPhone9,2", "iPhone9,4"]
 
-    // iPhone 14 Pro/Pro Max has issues with restart polling after 20 seconds from first connection on iOS 17+.
-    // We have no confirmed cases for iPhone 14/14 Plus ("iPhone14,7", "iPhone14,8")
-    private static let brokenRestartPollingDevices = ["iPhone15,2", "iPhone15,3"]
+    // iPhone 14 Pro/Pro Max and iPhone 15 Pro have issues with restarting polling after 20 seconds from the first connection on iOS 17+. We assume that all new devices have this behavior. We have no confirmed cases for iPhone 14/14 Plus ("iPhone14,7", "iPhone14,8") at this time.
+    private static let correctRestartPollingDevices = [
+        "iPhone9,1", // iPhone 7 family
+        "iPhone9,2",
+        "iPhone9,3",
+        "iPhone9,4",
+        "iPhone10,1", // iPhone 8 family
+        "iPhone10,2",
+        "iPhone10,3",
+        "iPhone10,4",
+        "iPhone10,5",
+        "iPhone10,6", // iPhone X family
+        "iPhone11,2",
+        "iPhone11,4",
+        "iPhone11,6",
+        "iPhone11,8",
+        "iPhone12,1", // iPhone 11 family
+        "iPhone12,3",
+        "iPhone12,5",
+        "iPhone12,8", // iPhone SE 2nd-generation
+        "iPhone13,1", // iPhone 12 family
+        "iPhone13,2",
+        "iPhone13,3",
+        "iPhone13,4",
+        "iPhone14,2", // iPhone 13 family
+        "iPhone14,3",
+        "iPhone14,4",
+        "iPhone14,5",
+        "iPhone14,6", // iPhone SE 3rd-generation
+        "iPhone14,7", // iPhone 14. Not confirmed
+        "iPhone14,8", // iPhone 14 Plus. Not confirmed
+    ]
 
     private static var identifier: String = {
         var systemInfo = utsname()
@@ -47,5 +76,5 @@ public class NFCUtils {
         }
         return identifier
     }()
-    
+
 }


### PR DESCRIPTION
Проблема подтвердилась и на 15 Pro. Отсюда делаем предположение, что на всех новых девайсах будет новое поведение, поэтому я хардкожу исчерпывающий список устройств со старым поведением. Непонятно куда отнести 14/14 Plus. По анализу разборок вывод сделать не удалось. Решили, что раз обращений не было, не будем на них раскатывать фикс