### PR TITLE
IOS-6085: Make EntropyLength words count public

### DIFF
--- a/TangemSdk/TangemSdk/Crypto/BIP39/EntropyLength.swift
+++ b/TangemSdk/TangemSdk/Crypto/BIP39/EntropyLength.swift
@@ -15,7 +15,7 @@ public enum EntropyLength: Int, CaseIterable {
     case bits224 = 224
     case bits256 = 256
 
-    var wordCount: Int {
+    public var wordCount: Int {
         switch self {
         case .bits128: return 12
         case .bits160: return 15


### PR DESCRIPTION
Чтобы в приложении можно было получать количество слов и не проводить расчет слов, а ориентироваться на изначальный источник правды - TangemSDK