### PR TITLE
IOS-6764 Fix write backup data logic

### DIFF
--- a/TangemSdk/TangemSdk/Operations/Backup/FinalizeBackupCardTask.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/FinalizeBackupCardTask.swift
@@ -43,14 +43,15 @@ class FinalizeBackupCardTask: CardSessionRunnable {
             completion(.failure(.missingPreflightRead))
             return
         }
-        
-        if case .noBackup = card.backupStatus {
+
+        switch card.backupStatus {
+        case .noBackup: // The direct case
             let command = LinkPrimaryCardCommand(primaryCard: primaryCard,
                                                  backupCards: backupCards,
                                                  attestSignature: attestSignature,
                                                  accessCode: accessCode,
                                                  passcode: passcode)
-            
+
             command.run(in: session) { linkResult in
                 switch linkResult {
                 case .success:
@@ -59,7 +60,9 @@ class FinalizeBackupCardTask: CardSessionRunnable {
                     completion(.failure(error))
                 }
             }
-        } else {
+        case .active: // Inconsistence case. The card status is ok, but sdk status is incompleted. We shoul check all wallets later on the app side.
+            readWallets(in: session, completion: completion)
+        default: // only an interrupted case is possible
             writeBackupData(in: session, completion: completion)
         }
     }

--- a/TangemSdk/TangemSdk/Operations/Backup/FinalizeBackupCardTask.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/FinalizeBackupCardTask.swift
@@ -60,7 +60,7 @@ class FinalizeBackupCardTask: CardSessionRunnable {
                     completion(.failure(error))
                 }
             }
-        case .active: // Inconsistence case. The card status is ok, but sdk status is incompleted. We shoul check all wallets later on the app side.
+        case .active: // Inconsistence case. The card status is ok, but sdk status is incompleted. We should check all wallets later on the app side.
             readWallets(in: session, completion: completion)
         default: // only an interrupted case is possible
             writeBackupData(in: session, completion: completion)

--- a/TangemSdk/TangemSdk/Operations/Backup/WriteBackupDataCommand.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/WriteBackupDataCommand.swift
@@ -46,10 +46,6 @@ final class WriteBackupDataCommand: Command {
         if card.backupStatus == .noBackup {
             return .backupFailedCardNotLinked
         }
-        
-        if !card.wallets.isEmpty {
-            return .backupFailedNotEmptyWallets(cardId: card.cardId)
-        }
 
         return nil
     }


### PR DESCRIPTION
Обновил логику финализации бэкапа на бэкапных картах. Теперь можно будет безопасно продолжать бэкап после прерывания сессии.