### PR TITLE
IOS-6859 Check for cards count

### DIFF
--- a/TangemSdk/TangemSdk/Operations/Backup/BackupService.swift
+++ b/TangemSdk/TangemSdk/Operations/Backup/BackupService.swift
@@ -214,7 +214,7 @@ public class BackupService: ObservableObject {
             || repo.data.primaryCard == nil
             || repo.data.backupCards.isEmpty {
             currentState = .preparing
-        } else if repo.data.attestSignature == nil || repo.data.backupData.isEmpty {
+        } else if repo.data.attestSignature == nil || repo.data.backupData.count < repo.data.backupCards.count {
             currentState = .finalizingPrimaryCard
         } else if repo.data.finalizedBackupCardsCount < repo.data.backupCards.count {
             currentState = .finalizingBackupCard(index: repo.data.finalizedBackupCardsCount + 1)


### PR DESCRIPTION
Если прервать финализацию основной карты при копировании, то при дальнейшем восстановлении бэкапа проверялся только факт присутствия данных, без учета количество бэкапных карт. Получалась ситуация, что для одной карты данные были, а для второй - нет. Теперь проверка корректная и позволяет продолжить бэкап с того же места