### PR TITLE
IOS-6807 Add backup cards count

### DIFF
--- a/TangemSdk/TangemSdk/Common/Card/Card.swift
+++ b/TangemSdk/TangemSdk/Common/Card/Card.swift
@@ -121,7 +121,16 @@ public extension Card {
                 return 0
             }
         }
-        
+
+        public var backupCardsCount: Int {
+            switch self {
+            case .active(let cardsCount):
+                return cardsCount
+            default:
+                return 0
+            }
+        }
+
         public init(from decoder: Decoder) throws {
             let codableStruct = try BackupStatusCodable(from: decoder)
             try self.init(from: codableStruct.status, cardsCount: codableStruct.cardsCount )


### PR DESCRIPTION
Нам нужно различать слинкованные карты от бэкапных карт, потому что это влияет на поведение. 